### PR TITLE
add ame backend

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,0 +1,46 @@
+name: Test
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false  # Let other jobs keep running even if one fails
+      matrix:
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        os: [ ubuntu-latest ]
+        dpl_mpi_backend: ['ame', 'mpi4py']
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        trap 'echo -e "$ $BASH_COMMAND"' DEBUG
+        sudo apt-get update
+        sudo apt-get install libopenmpi-dev
+        python -m pip install --upgrade pip
+        pip install flake8 pytest pytest-cov codecov
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+        python -m pip list
+        python -m pip install -e '.[all]'
+    - name: Lint with flake8
+      run: |
+        # stop the build if there are Python syntax errors or undefined names
+        python -m flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+        python -m flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+    - name: Test with pytest
+      run: |
+        DLP_MPI_BACKEND=${{ matrix.python-version }} python -m pytest
+    - name: Codecov
+      run: |
+        codecov

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false  # Let other jobs keep running even if one fails
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
         os: [ ubuntu-latest ]
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
         os: [ ubuntu-latest ]
-        dpl_mpi_backend: ['ame', 'mpi4py']
+        dlp_mpi_backend: ['ame', 'mpi4py']
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
@@ -40,7 +40,8 @@ jobs:
         python -m flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Test with pytest
       run: |
-        DLP_MPI_BACKEND=${{ matrix.dpl_mpi_backend }} python -m pytest
+        export DLP_MPI_BACKEND=${{ matrix.dlp_mpi_backend }}
+        python -m pytest
     - name: Codecov
       run: |
         codecov

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -15,7 +15,6 @@ jobs:
       matrix:
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
         os: [ ubuntu-latest ]
-        dlp_mpi_backend: ['ame', 'mpi4py']
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
@@ -40,7 +39,6 @@ jobs:
         python -m flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Test with pytest
       run: |
-        export DLP_MPI_BACKEND=${{ matrix.dlp_mpi_backend }}
         python -m pytest
     - name: Codecov
       run: |

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -40,7 +40,7 @@ jobs:
         python -m flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Test with pytest
       run: |
-        DLP_MPI_BACKEND=${{ matrix.python-version }} python -m pytest
+        DLP_MPI_BACKEND=${{ matrix.dpl_mpi_backend }} python -m pytest
     - name: Codecov
       run: |
         codecov

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false  # Let other jobs keep running even if one fails
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
         os: [ ubuntu-latest ]
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -39,6 +39,9 @@ jobs:
         python -m flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Test with pytest
       run: |
+        trap 'echo -e "$ $BASH_COMMAND"' DEBUG
+        export OMP_NUM_THREADS=1
+        export MKL_NUM_THREADS=1
         python -m pytest
     - name: Codecov
       run: |

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ To start the processes `mpiexec` can be used. Most HPC systems support MPI to sc
 
 Since each process should operate on different examples, MPI provides the variables `RANK` and `SIZE`, where `SIZE` is the number of workers and `RANK` is a unique identifier from `0` to `SIZE - 1`.
 The easiest way to improve the execution time is to process `examples[RANK::SIZE]` on each worker.
-This is a round robin load balancing (`dlp_mpi.split_round_robin`).
+This is a round-robin load balancing (`dlp_mpi.split_round_robin`).
 A more advanced load balancing is `dlp_mpi.split_managed`, where one process manages the load and assigns a new task to a worker once he finishes the last task.
 
 When in the end of a program all results should be summarized or written in a single file, communication between all processes is nessesary.
@@ -162,7 +162,7 @@ The communication between the processes is only the `result` and the index to ge
 
 # Availabel utilities and functions
 
-Note: `dlp_mpi` has dummy implementations, when `mpi4py` is not installed and the enviroment indicate that no MPI is used (Useful for running on a laptop).
+Note: `dlp_mpi` has dummy implementations, when `mpi4py` is not installed and the environment indicates that no MPI is used (Useful for running on a laptop).
 
  - `dlp_mpi.RANK` or `mpi4py.MPI.COMM_WORLD.rank`: The rank of the process. To avoid programming errors, `if dlp_mpi.RANK: ...` will fail.
  - `dlp_mpi.SIZE` or `mpi4py.MPI.COMM_WORLD.size`: The number of processes.
@@ -173,36 +173,36 @@ Note: `dlp_mpi` has dummy implementations, when `mpi4py` is not installed and th
 
 The advanced functions that are provided in this package are
 
- - `split_round_robin(examples)`: Zero communication split of the data. The default is identically to `examples[dlp_mpi.RANK::dlp_mpi.SIZE]`.
- - `split_managed(examples)`: The master process manages the load balance, while the others do the work. Note: The master process does not distribute the examples. It is assumed that examples have the same order on each worker.
- - `map_unordered(work_load, examples)`: The master process manages the load balance, while the others execute the `work_load` function. The result is send back to the master process.
+ - `split_round_robin(examples)`: Zero communication split of the data. The default is identical to `examples[dlp_mpi.RANK::dlp_mpi.SIZE]`.
+ - `split_managed(examples)`: The master process manages the load balance while the others do the work. Note: The master process does not distribute the examples. It is assumed that examples have the same order on each worker.
+ - `map_unordered(work_load, examples)`: The master process manages the load balance, while the others execute the `work_load` function. The result is sent back to the master process.
 
 
 # Runtime
 
-Without this package your code runs in serial.
+Without this package, your code runs in serial.
 The execution time of the following code snippets will be demonstrated by running it with this package.
 Regarding the color: The `examples = ...` is the setup code.
-Therefore, the code and the correspoding block representing the execution time it is blue in the code.
+Therefore, the code and the corresponding block representing the execution time it is blue in the code.
 
 ![(Serial Worker)](doc/tikz_split_managed_serial.svg)
 
-This easiest way to parallelize the workload (dark orange) is to do a round robin assignment of the load:
+This easiest way to parallelize the workload (dark orange) is to do a round-robin assignment of the load:
 `for example in dlp_mpi.split_round_robin(examples)`.
 This function call is equivalent to `for example in examples[dlp_mpi.RANK::dlp_mpi.SIZE]`.
 Thus, there is zero comunications between the workers.
-Only when it is nessesary to do some final work on the results of all data (e.g. calculating average metrics) a communication is nessesary.
+Only when it is nessesary to do some final work on the results of all data (e.g. calculating average metrics) a communication is necessary.
 This is done with the `gather` function.
-This functions returns the worker results in a list on the master process and the worker process gets a `None` return value.
-Depending on the workload the round robin assingment can be suboptimal.
-See the example block diagramm.
-Worker 1 got tasks that are relative long.
+This function returns the worker results in a list on the master process and the worker process gets a `None` return value.
+Depending on the workload the round-robin assingment can be suboptimal.
+See the example block diagram.
+Worker 1 got tasks that are relatively long.
 So this worker used much more time than the others.
 
 ![(Round Robin)](doc/tikz_split_managed_rr.svg)
 
 To overcome the limitations of the round robin assignment, this package helps to use a manager to assign the work to the workers.
-This optimizes the utilisation of the workers.
+This optimizes the utilization of the workers.
 Once a worker finished an example, it requests a new one from the manager and gets one assigned.
 Note: The communication is only which example should be processed (i.e. the index of the example) not the example itself.
 
@@ -211,9 +211,9 @@ Note: The communication is only which example should be processed (i.e. the inde
 An alternative to splitting the iterator is to use a `map` function.
 The function is then executed on a worker and the return value is sent back to the manager.
 Be carefull, that the loop body is fast enough, otherwise it can be a bottleneck.
-You should use the loop body only for book keeping, not for actual work load.
+You should use the loop body only for book keeping, not for actual workload.
 When a worker sends a task to the manager, the manager sends back a new task and enters the for loop body. 
-While the manager is in the loop body, he cannot react on requests of other workers, see the block diagramm:
+While the manager is in the loop body, he cannot react on requests of other workers, see the block diagram:
 
 ![(Managed Map)](doc/tikz_split_managed_map.svg)
 
@@ -222,8 +222,12 @@ While the manager is in the loop body, he cannot react on requests of other work
 
 You can install this package from pypi:
 ```bash
+pip install mpi4py
 pip install dlp_mpi
 ```
+where `mpi4py` is a backend for this package.
+You can skip the installation of `mpi4py` when you
+want to use the internal backend, it is called `ame`.
 
 To check if the installation was successful, try the following command:
 ```bash 
@@ -237,12 +241,29 @@ The command should print the numbers 0, 1, 2 and 3.
 The order is random.
 When that line prints 4 times a zero, something went wrong.
 
-This can happen, when you have no `mpi` installed or the installation is brocken.
+This can happen, when you have no `mpi` installed or the installation is broken.
 In a Debian-based Linux you can install it with `sudo apt install libopenmpi-dev`.
 When you do not have the rights to install something with `apt`, you could also install `mpi4py` with `conda`.
 The above `pip install` will install `mpi4py` from `pypi`.
 Be careful, that the installation from `conda` may conflict with your locally installed `mpi`. 
 Especially in High Performance Computing (HPC) environments this can cause troubles.
+
+# AME Backend
+
+The `ame` backend can be activated by setting the environment variable `DLP_MPI_BACKEND` to `ame`.
+It implements the interface of `mpi4py` that is used by `dlp_mpi`.
+
+It has the following properties:
+
+ - Pure python implementation with sockets:
+   - No issues with binaries: The actual motivation for `ame`
+   - Most likely slower than `mpi4py`: `MPI` has many optimizations that are not implemented in `ame`
+ - Communication only between root and workers, i.e. no communication between workers. So you cannot change the root in any function of `dlp_mpi`. But it is also unlikely that you need this feature. At least, I never needed it.
+ - Assumes a trusted environment: The communication is not encrypted. So do not use it in an untrusted environment.
+ - Supported launchers (mpiexec and srun):
+   - mpiexec build with PMI (uses PMI to setup the environment)
+   - mpiexec build with PMIx (use file based setup)
+   - slurm/srun with PMIx (use file based setup)
 
 # FAQ
 

--- a/dlp_mpi/ame/MPI.py
+++ b/dlp_mpi/ame/MPI.py
@@ -1,0 +1,13 @@
+"""
+This module provides the MPI interface, mimicking the mpi4py package.
+"""
+
+from .constants import ANY_TAG, ANY_SOURCE
+from .core import COMM_WORLD, Status
+
+__all__ = [
+    'COMM_WORLD',
+    'Status',
+    'ANY_TAG',
+    'ANY_SOURCE',
+]

--- a/dlp_mpi/ame/__init__.py
+++ b/dlp_mpi/ame/__init__.py
@@ -1,18 +1,3 @@
-"""
-AME: async based mpi like framework for embarrassingly parallel workloads in pure python
-ame: A mpi4py like framework for embarrassingly parallel workloads in pure python
-
-mpys: mpi like framework for embarrassingly parallel workloads in pure python implemented with sockets
-
-msp (
-
-smp: simple mpi for embarrassingly parallel
-
-sockmpi: socket based mpi like framework for embarrassingly parallel workloads in pure python
-
-"""
-import sys
-
 # Mirroring the behaviour of mpi4py, MPI has to be explicitly be imported
 # from . import MPI
 

--- a/dlp_mpi/ame/__init__.py
+++ b/dlp_mpi/ame/__init__.py
@@ -1,0 +1,19 @@
+"""
+AME: async based mpi like framework for embarrassingly parallel workloads in pure python
+ame: A mpi4py like framework for embarrassingly parallel workloads in pure python
+
+mpys: mpi like framework for embarrassingly parallel workloads in pure python implemented with sockets
+
+msp (
+
+smp: simple mpi for embarrassingly parallel
+
+sockmpi: socket based mpi like framework for embarrassingly parallel workloads in pure python
+
+"""
+import sys
+
+# Mirroring the behaviour of mpi4py, MPI has to be explicitly be imported
+# from . import MPI
+
+# print('ame.__init__.py executed', sys.argv)

--- a/dlp_mpi/ame/constants.py
+++ b/dlp_mpi/ame/constants.py
@@ -1,0 +1,22 @@
+__all__ = [
+    'DEBUG',
+    'ANY_SOURCE',
+    'ANY_TAG',
+    'BCAST_TAG',
+    'GATHER_TAG',
+    'BARRIER_TAG',
+    'AUTHKEY_LENGTH',
+]
+
+DEBUG = False
+
+# MPI constants
+ANY_SOURCE = -2
+ANY_TAG = -1
+
+# Custom constants
+BCAST_TAG = -3
+GATHER_TAG = -4
+BARRIER_TAG = -5
+
+AUTHKEY_LENGTH = 64

--- a/dlp_mpi/ame/constants.py
+++ b/dlp_mpi/ame/constants.py
@@ -8,7 +8,9 @@ __all__ = [
     'AUTHKEY_LENGTH',
 ]
 
-DEBUG = False
+import os
+
+DEBUG = bool(os.environ.get('DLP_MPI_DEBUG', False))
 
 # MPI constants
 ANY_SOURCE = -2

--- a/dlp_mpi/ame/core/__init__.py
+++ b/dlp_mpi/ame/core/__init__.py
@@ -1,0 +1,1 @@
+from .core_v3 import *

--- a/dlp_mpi/ame/core/_init/common.py
+++ b/dlp_mpi/ame/core/_init/common.py
@@ -41,13 +41,14 @@ def get_authkey(force_random=False):
 
     >>> len(get_authkey()), type(get_authkey())
     (64, <class 'bytes'>)
-    >>> os.environ['AME_AUTHKEY'] = 'test'
+    >>> os.environ['AME_AUTHKEY'] = authkey_decode(b'test' * 16)
     >>> len(get_authkey()), type(get_authkey())
-    (3, <class 'bytes'>)
+    (64, <class 'bytes'>)
     >>> del os.environ['AME_AUTHKEY']
     """
     if not force_random and 'AME_AUTHKEY' in os.environ:
         authkey = os.environ['AME_AUTHKEY']
+        
         return authkey_encode(authkey)
     return os.urandom(AUTHKEY_LENGTH)
 
@@ -84,6 +85,6 @@ def authkey_encode(authkey):
     >>> authkey_encode('dGVzdHRlc3R0ZXN0dGVzdHRlc3R0ZXN0dGVzdHRlc3R0ZXN0dGVzdHRlc3R0ZXN0dGVzdHRlc3R0ZXN0dGVzdA==')
     b'testtesttesttesttesttesttesttesttesttesttesttesttesttesttesttest'
     """
-    authkey = base64.b64decode(authkey.encode('utf-8'))
-    assert len(authkey) == AUTHKEY_LENGTH, (len(authkey), AUTHKEY_LENGTH)
-    return authkey
+    authkey_ = base64.b64decode(authkey.encode('utf-8'))
+    assert len(authkey_) == AUTHKEY_LENGTH, (len(authkey_), len(authkey), AUTHKEY_LENGTH)
+    return authkey_

--- a/dlp_mpi/ame/core/_init/common.py
+++ b/dlp_mpi/ame/core/_init/common.py
@@ -1,0 +1,89 @@
+import os
+import socket
+import base64
+
+from ...constants import AUTHKEY_LENGTH
+
+
+def find_free_port():
+    # https://stackoverflow.com/a/45690594/5766934
+    import socket
+    from contextlib import closing
+
+    with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as s:
+        s.bind(('', 0))
+        s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        return s.getsockname()[1]
+
+
+def get_host_and_port():
+    """
+    Return a host and port that can be used by the root process.
+    This function should never be called by a non-root process.
+    """
+    # host = '127.0.0.1'
+    host = socket.gethostname()
+    port = find_free_port()
+    return host, port
+
+
+def get_authkey(force_random=False):
+    """
+    Generate a random 32-byte authentication key.
+
+    This key will be used to authenticate the connection between the
+    root process and the non-root processes.
+
+    Note: Your communication will not be encrypted and it is assumed, that
+          the program is running in a secure environment.
+          It protects mainly against accidental connections from other
+          programs.
+
+    >>> len(get_authkey()), type(get_authkey())
+    (64, <class 'bytes'>)
+    >>> os.environ['AME_AUTHKEY'] = 'test'
+    >>> len(get_authkey()), type(get_authkey())
+    (3, <class 'bytes'>)
+    >>> del os.environ['AME_AUTHKEY']
+    """
+    if not force_random and 'AME_AUTHKEY' in os.environ:
+        authkey = os.environ['AME_AUTHKEY']
+        return authkey_encode(authkey)
+    return os.urandom(AUTHKEY_LENGTH)
+
+
+def str_to_authkey(s):
+    """
+    >>> len(str_to_authkey('test')), type(str_to_authkey('test'))
+    (64, <class 'bytes'>)
+    """
+    # use md5 to hash the string to a 32-byte key
+    import hashlib
+    m = hashlib.sha512()
+    m.update(s.encode('utf-8'))
+    authkey = m.digest()
+    assert len(authkey) == AUTHKEY_LENGTH, (len(authkey), AUTHKEY_LENGTH)
+    return authkey
+
+
+def authkey_decode(authkey):
+    """
+    bytes to str
+
+    >>> authkey_decode(b'test'*16)
+    'dGVzdHRlc3R0ZXN0dGVzdHRlc3R0ZXN0dGVzdHRlc3R0ZXN0dGVzdHRlc3R0ZXN0dGVzdHRlc3R0ZXN0dGVzdA=='
+    """
+    assert len(authkey) == AUTHKEY_LENGTH, (len(authkey), AUTHKEY_LENGTH)
+    return base64.b64encode(authkey).decode('utf-8')
+
+
+def authkey_encode(authkey):
+    """
+    str to bytes
+
+    >>> authkey_encode('dGVzdHRlc3R0ZXN0dGVzdHRlc3R0ZXN0dGVzdHRlc3R0ZXN0dGVzdHRlc3R0ZXN0dGVzdHRlc3R0ZXN0dGVzdA==')
+    b'testtesttesttesttesttesttesttesttesttesttesttesttesttesttesttest'
+    """
+    authkey = base64.b64decode(authkey.encode('utf-8'))
+    assert len(authkey) == AUTHKEY_LENGTH, (len(authkey), AUTHKEY_LENGTH)
+    return authkey

--- a/dlp_mpi/ame/core/_init/get_init.py
+++ b/dlp_mpi/ame/core/_init/get_init.py
@@ -1,0 +1,64 @@
+import os
+
+DEBUG = False
+
+
+def get():
+    if 'SLURM_SRUN_COMM_HOST' in os.environ:
+        type_ = 'SLURM'
+        from .slurm import get_host_rank_size
+        host, port, rank, size, authkey = get_host_rank_size()
+        if DEBUG:
+            print(f'SLURM: {host}:{port}, Rank {rank} of {size}')
+    elif 'PMI_RANK' in os.environ:
+        type_ = 'MPICH / PMI'
+        from .pmi import get_host_rank_size
+        # IP is 127.0.0.1, i.e. localhost
+        host, port, rank, size, authkey = get_host_rank_size()
+        if DEBUG:
+            print(f'PMI: {host}:{port}, Rank {rank} of {size}')
+    elif 'OMPI_COMM_WORLD_RANK' in os.environ:
+        type_ = 'OpenMPI'
+        from .ompi_mca_orte import get_host_rank_size
+        # IP is 127.0.0.1, i.e. localhost
+        host, port, rank, size, authkey = get_host_rank_size()
+        if DEBUG:
+            print(f'OMPI: {host}:{port}, Rank {rank} of {size}')
+    elif 'AME_RANK' in os.environ:
+        type_ = 'AME'
+        from .common import str_to_authkey, authkey_encode
+        # Custom launcher
+        host = os.getenv("AME_HOST", '127.0.0.1')
+        port = int(os.getenv("AME_PORT",
+                              12345))  # ToDO: Replace the port with a free port
+        rank = int(os.getenv("AME_RANK", 0))
+        size = int(os.getenv("AME_SIZE", 1))
+        if 'AME_AUTHKEY' in os.environ:
+            authkey = authkey_encode(os.getenv("AME_AUTHKEY"))
+        else:
+            authkey = str_to_authkey(f'{host}:{port}')
+        if DEBUG:
+            print(f'AME: {host}:{port}, Rank {rank} of {size}')
+
+    else:
+        type_ = 'None'
+        from .common import str_to_authkey
+
+        rank = 0
+        size = 1
+        host = 'localhost'
+        port = -1
+        authkey = str_to_authkey(f'{host}:{port}')
+
+    assert isinstance(host, str), (host, port, rank, size, authkey, type_)
+    assert isinstance(port, int), (host, port, rank, size, authkey, type_)
+    assert isinstance(rank, int), (host, port, rank, size, authkey, type_)
+    assert isinstance(size, int), (host, port, rank, size, authkey, type_)
+    assert isinstance(authkey, bytes), (host, port, rank, size, authkey, type_)
+    return {
+        'host': host,
+        'port': port,
+        'rank': rank,
+        'size': size,
+        'authkey': authkey
+    }

--- a/dlp_mpi/ame/core/_init/ompi_mca_orte.py
+++ b/dlp_mpi/ame/core/_init/ompi_mca_orte.py
@@ -1,0 +1,63 @@
+import os
+import time
+from pathlib import Path
+from .common import get_host_and_port, get_authkey
+
+
+def get_host_rank_size():
+    """
+    >>> import tempfile
+    >>> import os
+    >>> os.environ['OMPI_COMM_WORLD_RANK'] = '0'
+    >>> os.environ['OMPI_COMM_WORLD_SIZE'] = '2'
+    >>> with tempfile.TemporaryDirectory() as tmpdir:
+    ...     os.environ['OMPI_MCA_orte_top_session_dir'] = tmpdir
+    ...     *vars, authkey1 = get_host_rank_size()
+    ...     print(vars)
+    ...     os.environ['OMPI_COMM_WORLD_RANK'] = '1'
+    ...     *vars, authkey2 = get_host_rank_size()
+    ...     print(vars)
+    ...     assert authkey1 == authkey2
+    ['T470', 47995, 0, 2]
+    ['T470', '47995', 1, 2]
+    """
+
+    # Using PMIx would be better, but I couldn't find how to get it work.
+
+    rank = int(os.environ['OMPI_COMM_WORLD_RANK'])
+    size = int(os.environ['OMPI_COMM_WORLD_SIZE'])
+
+    dir = Path(os.environ['OMPI_MCA_orte_top_session_dir'])
+    tmp_file = dir / 'host_and_port.txt_'
+    file = dir / 'host_and_port.txt'
+    assert tmp_file != file, f'{tmp_file} == {file}'
+
+    if rank == 0:
+        host, port = get_host_and_port()
+        authkey = get_authkey()
+        with open(tmp_file, 'w') as f:
+            f.write(f'{host}:{port}')
+        with open(tmp_file, 'ab') as f:
+            f.write(b'\n')
+            f.write(authkey)
+
+        os.rename(tmp_file, file)  # "atomic operation", see https://docs.python.org/3/library/os.html#os.rename
+    else:
+        # If this is not the first process, read the port from the port file
+        i = 0
+        while True:
+            i += 1
+            try:
+                # with open(file, 'r') as f:
+                #     host, port, authkey = f.read().split(':', maxsplit=2)
+                with open(file, 'rb') as f:
+                    host_port, authkey = f.read().split(b'\n', maxsplit=1)
+                    host, port = host_port.decode().split(':', maxsplit=1)
+                    port = int(port)
+                break
+            except FileNotFoundError as e:
+                if i > 3600:  # 6 minutes
+                    raise FileNotFoundError(f'File {file} not found after {i} tries.') from e
+                time.sleep(0.1)
+    return host, port, rank, size, authkey
+

--- a/dlp_mpi/ame/core/_init/ompi_mca_orte.py
+++ b/dlp_mpi/ame/core/_init/ompi_mca_orte.py
@@ -10,7 +10,7 @@ def get_host_rank_size():
     >>> import os
     >>> os.environ['OMPI_COMM_WORLD_RANK'] = '0'
     >>> os.environ['OMPI_COMM_WORLD_SIZE'] = '2'
-    >>> with tempfile.TemporaryDirectory() as tmpdir:
+    >>> with tempfile.TemporaryDirectory() as tmpdir:  # doctest: +ELLIPSIS
     ...     os.environ['OMPI_MCA_orte_top_session_dir'] = tmpdir
     ...     *vars, authkey1 = get_host_rank_size()
     ...     print(vars)
@@ -18,8 +18,8 @@ def get_host_rank_size():
     ...     *vars, authkey2 = get_host_rank_size()
     ...     print(vars)
     ...     assert authkey1 == authkey2
-    ['T470', 47995, 0, 2]
-    ['T470', '47995', 1, 2]
+    ['...', ..., 0, 2]
+    ['...', ..., 1, 2]
     """
 
     # Using PMIx would be better, but I couldn't find how to get it work.

--- a/dlp_mpi/ame/core/_init/pmi.py
+++ b/dlp_mpi/ame/core/_init/pmi.py
@@ -1,0 +1,136 @@
+import socket
+import os
+import re
+import base64
+
+from .common import get_host_and_port, get_authkey, authkey_encode, authkey_decode
+
+return_codes = {
+    0: ('PMI_SUCCESS', 'operation completed successfully'),
+    -1: ('PMI_FAIL', 'operation failed'),
+    1: ('PMI_ERR_INIT', 'PMI not initialized'),
+    2: ('PMI_ERR_NOMEM', 'input buffer not large enough'),
+    3: ('PMI_ERR_INVALID_ARG', 'invalid argument'),
+    4: ('PMI_ERR_INVALID_KEY', 'invalid key argument'),
+    5: ('PMI_ERR_INVALID_KEY_LENGTH', 'invalid key length argument'),
+    6: ('PMI_ERR_INVALID_VAL', 'invalid val argument'),
+    7: ('PMI_ERR_INVALID_VAL_LENGTH', 'invalid val length argument'),
+    8: ('PMI_ERR_INVALID_LENGTH', 'invalid length argument'),
+    9: ('PMI_ERR_INVALID_NUM_ARGS', 'invalid number of arguments'),
+    10: ('PMI_ERR_INVALID_ARGS', 'invalid args argument'),
+    11: ('PMI_ERR_INVALID_NUM_PARSED', 'invalid num_parsed length argument'),
+    12: ('PMI_ERR_INVALID_KEYVALP', 'invalid keyvalp argument'),
+    13: ('PMI_ERR_INVALID_SIZE', 'invalid size argument'),
+}
+
+
+class PMI:
+    def __init__(self, verbose=False):
+        pmi_fd = int(os.environ['PMI_FD'])
+        self.sock = socket.fromfd(pmi_fd, socket.AF_UNIX, socket.SOCK_STREAM)
+        self.verbose = verbose
+        self.kvsname = 'mykvs'
+
+    def exec(self, msg: str, check_rc=True):
+        if isinstance(msg, str):
+            msg = msg.encode()
+        msg = msg.strip() + b'\n'
+        if self.verbose:
+            print(f'Send {msg.decode().strip()}', flush=True)
+
+        self.sock.sendall(msg)
+        response = self.sock.recv(1024)
+        if self.verbose:
+            print(f'Received ({rank}):', response.decode().strip(), flush=True)
+        if check_rc:
+            try:
+                rc = int(re.search(b'rc=(\d+)', response).group(1))
+            except Exception:
+                raise RuntimeError('Could not parse return code', response)
+            if rc != 0:
+                raise RuntimeError(return_codes[rc], response)
+            return response, rc
+        else:
+            return response, None
+
+    def init(self):
+        response, rc = self.exec('cmd=init pmi_version=1 pmi_subversion=1\n')
+
+        if response != b'cmd=response_to_init pmi_version=1 pmi_subversion=1 rc=0\n':
+            raise RuntimeError(return_codes[rc], response)
+
+    def put(self, key, value):
+        response, rc = self.exec(f'cmd=put kvsname={self.kvsname} key={key} value={value}\n')
+        if response != b'cmd=put_result rc=0 msg=success\n':
+            raise RuntimeError(return_codes[rc], response)
+
+    def get(self, key):
+        response, rc = self.exec(f'cmd=get kvsname={self.kvsname} key={key}\n')
+        if not response.startswith(b'cmd=get_result rc=0 msg=success value='):
+            raise RuntimeError(return_codes[rc], response)
+        return response.split(b'value=')[1].decode().strip()
+
+    def __setitem__(self, key, value):
+        self.put(key, value)
+
+    def __getitem__(self, key):
+        return self.get(key)
+
+    def barrier(self):
+        response, rc = self.exec('cmd=barrier_in\n', check_rc=False)
+        if response != b'cmd=barrier_out\n':
+            raise RuntimeError(return_codes[rc], response)
+
+    def close(self):
+        self.sock.close()
+
+
+def get_host_rank_size():
+    rank = int(os.environ['PMI_RANK'])
+    size = int(os.environ['PMI_SIZE'])
+
+    pmi = PMI()
+    try:
+        if rank == 0:
+            host, port = get_host_and_port()
+            authkey = get_authkey()
+
+            pmi.init()
+            pmi['mykey'] = f'{host}:{port}'
+            pmi['authkey'] = authkey_decode(authkey)
+            pmi.barrier()
+            pmi.barrier()
+        else:
+            pmi.barrier()
+            host, port = pmi['mykey'].split(':', maxsplit=1)
+            authkey = authkey_encode(pmi['authkey'])
+            port = int(port)
+            pmi.barrier()
+    finally:
+        pmi.close()
+    return host, port, rank, size, authkey
+
+
+if __name__ == '__main__':
+
+    # Assume fd is the file descriptor
+    rank = int(os.environ['PMI_RANK'])
+    size = int(os.environ['PMI_SIZE'])
+
+
+    pmi = PMI(verbose=True)
+    if rank == 0:
+        # Get the PMI_FD environment variable
+
+        pmi.init()
+        pmi['mykey'] = '127.0.0.1:12345'
+        pmi.barrier()
+        pmi.barrier()
+    else:
+        pmi.barrier()
+        print(f'get {rank}', pmi['mykey'])
+        pmi.barrier()
+
+    # print(rank, data)
+
+

--- a/dlp_mpi/ame/core/_init/pmi.py
+++ b/dlp_mpi/ame/core/_init/pmi.py
@@ -44,7 +44,7 @@ class PMI:
             print(f'Received ({rank}):', response.decode().strip(), flush=True)
         if check_rc:
             try:
-                rc = int(re.search(b'rc=(\d+)', response).group(1))
+                rc = int(re.search(b'rc=(\\d+)', response).group(1))
             except Exception:
                 raise RuntimeError('Could not parse return code', response)
             if rc != 0:

--- a/dlp_mpi/ame/core/_init/pmix.py
+++ b/dlp_mpi/ame/core/_init/pmix.py
@@ -1,0 +1,96 @@
+"""
+This code doesn't work!!!
+The documentation for PMIx is terrible.
+"""
+from cffi import FFI
+
+# Define the C header for PMIx
+pmix_header = """
+    int PMIx_Init(int *rc, char ***err);
+    int PMIx_Finalize(void);
+    int PMIx_Spawn(int *rc, char *cmd, char *argv[]);
+    int PMIx_Put(char *key, void *val, size_t vallen);
+    int PMIx_Commit(void);
+    int PMIx_Get(char *key, void **val, size_t *vallen);
+"""
+
+# Create a ffi object
+ffi = FFI()
+
+
+
+# Load the PMIx shared library
+pmix_lib = ffi.dlopen('/lib/x86_64-linux-gnu/libpmix.so')  # Update the path accordingly
+
+# Parse the C header
+ffi.cdef(pmix_header)
+
+# Initialize PMIx
+def initialize():
+    rc = ffi.new("int *")
+    err = ffi.new("char ***")
+    result = pmix_lib.PMIx_Init(rc, err)
+    if result != 0:
+        raise RuntimeError(f"Failed to initialize PMIx")
+    return rc[0]
+
+# Finalize PMIx
+def finalize():
+    result = pmix_lib.PMIx_Finalize()
+    if result != 0:
+        raise RuntimeError("Failed to finalize PMIx")
+    return result
+
+# # Spawn additional processes
+# def spawn_processes(num_procs):
+#     cmd = ffi.new("char []", b"python")  # Example command to execute another Python script
+#     args = [ffi.new("char []", b"child_script.py")]  # Example arguments for the child script
+#     argv = ffi.new("char *[]", args + [ffi.NULL])
+#     rc = ffi.new("int *")
+#     result = pmix_lib.PMiX_Spawn(rc, cmd, argv)
+#     if result != 0:
+#         raise RuntimeError("Failed to spawn processes")
+#     return rc[0]
+
+# Put data into PMIx key-value store
+def put_data(key, value):
+    c_key = ffi.new("char []", key.encode())
+    c_value = ffi.new("char []", value.encode())
+    result = pmix_lib.PMIx_Put(c_key, c_value, len(value))
+    if result != 0:
+        raise RuntimeError("Failed to put data into PMIx key-value store")
+    return result
+
+# Commit changes to PMIx key-value store
+def commit():
+    result = pmix_lib.PMIx_Commit()
+    if result != 0:
+        raise RuntimeError("Failed to commit changes to PMIx key-value store")
+    return result
+
+# Get data from PMIx key-value store
+def get_data(key):
+    c_key = ffi.new("char []", key.encode())
+    c_value = ffi.new("void **")
+    vallen = ffi.new("size_t *")
+    result = pmix_lib.PMIx_Get(c_key, c_value, vallen)
+    if result != 0:
+        raise RuntimeError("Failed to get data from PMIx key-value store")
+    return ffi.string(c_value[0], vallen[0]).decode() if c_value[0] else None
+
+if __name__ == '__main__':
+    import os
+    rank = int(os.environ['PMIX_RANK'])
+    size = int(os.environ['OMPI_COMM_WORLD_SIZE'])
+
+    if rank == 0:
+        initialize()
+        data = "Hello from rank 0"
+        put_data("mykey", data)
+        commit()
+        finalize()
+    else:
+        import time
+        time.sleep(1)
+        # data = get_data("mykey")
+        # print(f"Rank {rank} received data: {data}")

--- a/dlp_mpi/ame/core/_init/slurm.py
+++ b/dlp_mpi/ame/core/_init/slurm.py
@@ -1,0 +1,66 @@
+import os
+from .common import str_to_authkey
+
+
+def expand_node_list(node_list):
+    """
+    >>> expand_node_list('node[01-03,04,05]')
+    ['node01', 'node02', 'node03', 'node04', 'node05']
+    """
+    nodes = []
+    base, ranges = node_list.split('[')
+    range_parts = ranges.strip(']').split(',')
+    for range_part in range_parts:
+        if '-' in range_part:
+            start, end = range_part.split('-')
+            prefix_len = len(start)
+            for i in range(int(start), int(end) + 1):
+                nodes.append(f"{base}{str(i).zfill(prefix_len)}")
+        else:
+            nodes.append(f"{base}{range_part}")
+    return nodes
+
+
+def get_host_rank_size():
+    ###########################################################################
+    # HOST
+    ###########################################################################
+    # SLURM_STEP_NODELIST n2cn[0501,0509]
+    # Is it correct, that the first node is the one where the rank 0 is running?
+    _HOST = expand_node_list(os.environ['SLURM_STEP_NODELIST'])[0]
+
+    # SLURM_SRUN_COMM_HOST is the IP of the submit node in salloc, hence I got OSError: [Errno 99] Cannot assign requested address
+    # _HOST = os.environ['SLURM_SRUN_COMM_HOST']
+
+    # maybe not always defined
+    # _HOST = os.environ['PMIX_HOSTNAME']
+
+    # SLURM_STEP_NODELIST=cn-0256  Might be wrong, if srun uses a subset of the nodes
+    # _HOST = os.environ['SLURMD_NODENAME']  # The name of the node, where the task is running -> useless
+    # _HOST = os.environ['SLURM_TOPOLOGY_ADDR']  # SLURM_TOPOLOGY_ADDR=opasw[06,14-15,07,11].opasw13.cn-0256
+
+    ###########################################################################
+    # PORT
+    ###########################################################################
+    # It is not clear, whether the port is free to be used.
+    # Given the fact, that SLURM_SRUN_COMM_HOST is the IP of the submit node in
+    # salloc, it is probably not planned to be used outside of slum plugins.
+    # _PORT = int(os.environ['SLURM_SRUN_COMM_PORT'])
+
+    # I cannot find a proper documentation for SLURM_STEP_RESV_PORTS.
+    # But https://supercloud.mit.edu/tensorboard indicates that it can be used
+    # for used code. So I will use it.
+    # SLURM_STEP_RESV_PORTS=17058-17059
+    _PORT = int(os.environ['SLURM_STEP_RESV_PORTS'].split('-')[0])
+
+    ###########################################################################
+    # RANK, SIZE and authkey
+    ###########################################################################
+    RANK = int(os.environ['SLURM_PROCID'])  # or PMIX_RANK,
+    SIZE = int(os.environ['SLURM_NTASKS'])  # or SLURM_NPROCS, PMIX_SIZE
+
+    authkey = os.getenv(
+        "AME_AUTHKEY",
+        str_to_authkey(os.environ['SLURM_JOB_START_TIME'] + __file__))
+
+    return _HOST, _PORT, RANK, SIZE, authkey

--- a/dlp_mpi/ame/core/_init/slurm.py
+++ b/dlp_mpi/ame/core/_init/slurm.py
@@ -6,19 +6,26 @@ def expand_node_list(node_list):
     """
     >>> expand_node_list('node[01-03,04,05]')
     ['node01', 'node02', 'node03', 'node04', 'node05']
+    >>> expand_node_list('node01')
+    ['node01']
     """
-    nodes = []
-    base, ranges = node_list.split('[')
-    range_parts = ranges.strip(']').split(',')
-    for range_part in range_parts:
-        if '-' in range_part:
-            start, end = range_part.split('-')
-            prefix_len = len(start)
-            for i in range(int(start), int(end) + 1):
-                nodes.append(f"{base}{str(i).zfill(prefix_len)}")
-        else:
-            nodes.append(f"{base}{range_part}")
-    return nodes
+    if '[' in node_list:
+        nodes = []
+        base, ranges = node_list.split('[')
+        range_parts = ranges.strip(']').split(',')
+        for range_part in range_parts:
+            if '-' in range_part:
+                start, end = range_part.split('-')
+                prefix_len = len(start)
+                for i in range(int(start), int(end) + 1):
+                    nodes.append(f"{base}{str(i).zfill(prefix_len)}")
+            else:
+                nodes.append(f"{base}{range_part}")
+        return nodes
+    elif ',' in node_list:
+        return node_list.split(',')
+    else:
+        return [node_list]
 
 
 def get_host_rank_size():

--- a/dlp_mpi/ame/core/con_v2.py
+++ b/dlp_mpi/ame/core/con_v2.py
@@ -482,10 +482,10 @@ async def establish_connection(
         # runner,
         *,
         depth,
-        host=_HOST,  # IP of rank 0
-        port=_PORT,  # port of rank 0
-        rank=RANK,  # rank of this process
-        size=SIZE,
+        host,  # IP of rank 0
+        port,  # port of rank 0
+        rank,  # rank of this process
+        size,
         debug=DEBUG,
 ):
     rank_to_p2p = Dispatcher()

--- a/dlp_mpi/ame/core/con_v2.py
+++ b/dlp_mpi/ame/core/con_v2.py
@@ -1,0 +1,582 @@
+import json
+import pickle
+import struct
+import socket
+import selectors
+import types
+import asyncio
+import time
+
+from paderbox.utils.mapping import Dispatcher
+
+from ..constants import *
+from .logger import info
+# from ame.core.core import TagError, tag_match
+
+__all__ = [
+    # 'P2P',
+    'PickleBackend',
+    'JsonBackend',
+    # 'ABCBackend',
+]
+
+
+class TagError(Exception):
+    pass
+
+def tag_match(got, expected):
+    """
+    >>> tag_match(1, 1)
+    True
+    >>> tag_match(1, 2)
+    False
+    >>> tag_match(1, ANY_TAG)
+    True
+    >>> tag_match(BCAST_TAG, ANY_TAG)
+    False
+    """
+    assert got != ANY_TAG, got
+    if expected == ANY_TAG and got >= 0:
+        return True
+    return expected == got
+
+
+if DEBUG:
+    def _debug_wait_for(aw):
+        return asyncio.wait_for(aw, 10 + 3 * (SIZE - RANK))
+else:
+    def _debug_wait_for(aw):
+        return aw
+
+
+class TrueFalseEvent:
+    def __init__(self):
+        self._event_true = asyncio.Event()
+        self._event_false = asyncio.Event()
+        self._event_false.set()
+
+    def set(self):
+        self._event_true.set()
+        self._event_false.clear()
+
+    def clear(self):
+        self._event_true.clear()
+        self._event_false.set()
+
+    async def wait_true(self):
+        await self._event_true.wait()
+
+    async def wait_false(self):
+        await self._event_false.wait()
+
+class c:
+    reset = '\033[0m'
+    magenta = '\033[35m'
+    cyan = '\033[36m'
+
+class P2Pv2:
+    """
+    Idea for recv:
+     - The buffer_task runs in the background and fills the buffer with the next tag.
+     - The user can check if the buffer is ready with the correct tag by using the ready() method.
+     - The user can then call recv() to get the data.
+    Motivation:
+    The buffer task runs in the background and reads the tag from the message.
+    Once the tag is known, we know, that another RANK wants to send data.
+    The recv has to solve two problems:
+     - It may want to recv data from any rank, so it want to know the first
+       process that is ready. If another P2P was faster, the data should be
+       kept for the next recv call.
+     - The tag has to match the expected tag.
+
+    This class is used as follows:
+     - The buffer tasks runs always.
+     - The ready() is called and might be canceled.
+     - The recv() is called and is not allowed to be canceled.
+       i.e. the data has to be used.
+
+    """
+    def __init__(self, reader, writer, depth, rank, backend='json', debug=False):
+        self.reader: asyncio.StreamReader = reader
+        self.writer: asyncio.StreamWriter = writer
+
+        self.depth = depth
+        self.rank = rank
+        self.debug = debug
+
+        self.buffer = None
+
+        self.backend = backend
+
+        self._shutdown = False
+
+        self._data_ready = asyncio.Event()
+        self._load_data = asyncio.Event()
+
+        # self._buffer_task = None
+        self._buffer_task = asyncio.create_task(self.buffer_task())
+        # The garbage collector (GC) sometimes closes the loop, before the del
+        # is called. Additionally, it looks like the __del__ might be called,
+        # while a coroutine is running. So supress the warning and errors:
+        #    Disable the logging and let the GC do its job, instead of a clean
+        #    shutdown, which is impossible without a context manager, which
+        #    cannot be used to stay compatible with the MPI interface.
+        self._buffer_task._log_destroy_pending = False
+
+    @property
+    def backend(self):
+        return self._backend
+
+    @backend.setter
+    def backend(self, value):
+        if value == 'pickle': self._backend = PickleBackend()
+        elif value == 'json': self._backend = JsonBackend()
+        else: raise TypeError(value)
+
+    async def shutdown(self):
+        if self.debug:
+            info()
+
+        self._shutdown = True
+        if self._buffer_task:
+            if self.debug:
+                info('cancel buffer task')
+            # self._load_data.set()
+            self._buffer_task.cancel()
+            await self._buffer_task
+            if self.debug:
+                info('buffer task canceled')
+
+        self.writer.close()
+
+    def __del__(self):
+        # pass
+        assert self.buffer is None, 'Impl error'
+        # info(f'{self.depth} {self.rank}')
+
+        # if self._buffer_task:
+        #     if self.debug:
+        #         info('cancel buffer task')
+        #     # self._load_data.set()
+        #     self._buffer_task.cancel()
+        #     # await self._buffer_task
+        #     if self.debug:
+        #         info('buffer task canceled')
+
+        # self.writer.close()
+
+    def to_idle(self):
+        assert not self._load_data.is_set(), 'timing issue'
+        self._shutdown = True
+        self._load_data.set()
+
+    async def buffer_task(self):
+        while True:
+            # await self._data_ready.wait_false()
+            try:
+                await self._load_data.wait()
+            except asyncio.CancelledError:
+                return
+            self._load_data.clear()
+
+            if self._shutdown:
+                # self._shutdown = False
+                # self._buffer_task = None
+                return
+
+            try:
+                header = await _debug_wait_for(self.reader.read(8))
+            except asyncio.CancelledError:
+                return
+            if not header:
+                return
+                # raise EOFError(f'{self.depth} EOF', header)
+
+            length, msg_tag = struct.unpack('ii', header)
+            # data = await _debug_wait_for(self.reader.read(length))
+            assert self.buffer is None, (self.buffer, 'Impl error')
+            self.buffer = length, msg_tag
+
+            assert self._data_ready.is_set() is False, 'Impl error'
+
+            # self._buffer_task = None
+            self._data_ready.set()
+
+    async def ready(self, tag):
+        assert self._load_data.is_set() is False, 'Impl error'
+        self._load_data.set()
+        # if self._buffer_task is None:
+        #     self._buffer_task = asyncio.create_task(self.buffer_task())
+        #     self._buffer_task.__log_destroy_pending = False
+
+        await self._data_ready.wait()
+        if tag_match(self.buffer[1], tag):
+            return True
+        else:
+            return False
+
+    async def get_data(self, tag=ANY_TAG, status=None):
+        length, msg_tag = self.buffer
+
+        if self.debug:
+            info(f'{self.depth} from {self.rank} with tag {msg_tag}')
+        data = await _debug_wait_for(self.reader.read(length))
+        if self.debug:
+            info(f'{self.depth} from {self.rank} with tag {msg_tag} data: {data}')
+        self.buffer = None
+        self._data_ready.clear()
+
+        if status:
+            status.source = self.rank
+            status.tag = msg_tag
+
+        assert tag_match(msg_tag, tag), (msg_tag, tag, 'Tag mismatch. This is a critical issue, use ready() to check the tag before calling recv()')
+        data = self.backend._loads(data)
+        if self.debug:
+            info(f'{self.depth} from {self.rank} with tag {msg_tag} data: {data} status: {status}')
+        return data
+
+    async def recv(self, tag=ANY_TAG, status=None):
+        if await self.ready(tag):
+            if self.debug:
+                info(f'{self.depth} from {self.rank}')
+            data = await self.get_data(tag, status=status)
+            if self.debug:
+                info(f'{self.depth} from {self.rank} data: {data} status: {status}')
+            return data
+        else:
+            assert self.buffer is not None, 'Impl error'
+            raise TagError(f'{self.depth} Expected tag {tag}, got {self.buffer[1]}')
+
+    async def send(self, data, tag):
+        # print(f'{self.depth} {c.cyan}send{c.reset} {self._decode(data)} to {self.rank} with tag {tag}')
+
+        data = self.backend._dumps(data)
+
+        assert tag != ANY_TAG, tag
+        header = struct.pack(
+            'ii',
+            len(data),  # MPI is also limited to 2GB
+            tag,
+        )
+        self.writer.write(header)
+        self.writer.write(data)
+        try:
+            await _debug_wait_for(self.writer.drain())
+        except ConnectionResetError:
+            raise ConnectionResetError(f'{self.depth} data: {data} ({pickle.loads(data)}) tag: {tag}, rank: {self.rank}')
+
+
+
+
+# class P2P:
+#     def __init__(self, reader, writer, depth, rank, backend='json'):
+#         self.reader: asyncio.StreamReader = reader
+#         self.writer: asyncio.StreamWriter = writer
+#         self.buffer = None
+#         self.depth = depth
+#         self.rank = rank
+#
+#         self._buffer_task = None
+#
+#         if backend == 'pickle':
+#             self.backend = PickleBackend()
+#         elif backend == 'json':
+#             self.backend = JsonBackend()
+#         else:
+#             raise TypeError(backend)
+#
+#     def _decode(self, data):
+#         try:
+#             return f'pickle({pickle.loads(data)!r})'
+#         except pickle.UnpicklingError:
+#             pass
+#         try:
+#             return f'json({json.loads(data)!r})'
+#         except json.JSONDecodeError:
+#             pass
+#         return f'{data!r}'
+#
+#     async def send(self, data, tag):
+#         # print(f'{self.depth} {c.cyan}send{c.reset} {self._decode(data)} to {self.rank} with tag {tag}')
+#
+#         data = self.backend._dumps(data)
+#
+#         assert tag != ANY_TAG, tag
+#         header = struct.pack(
+#             'ii',
+#             len(data),  # MPI is also limited to 2GB
+#             tag,
+#         )
+#         self.writer.write(header)
+#         self.writer.write(data)
+#         try:
+#             await _debug_wait_for(self.writer.drain())
+#         except ConnectionResetError:
+#             raise ConnectionResetError(f'{self.depth} data: {data} ({pickle.loads(data)}) tag: {tag}, rank: {self.rank}')
+#
+#     async def set_buffer(self):
+#         header = await _debug_wait_for(self.reader.read(8))
+#         if not header:
+#             self._buffer_task = None
+#             return
+#             # raise EOFError(f'{self.depth} EOF', header)
+#
+#         length, msg_tag = struct.unpack('ii', header)
+#         data = await _debug_wait_for(self.reader.read(length))
+#         self.buffer = data, msg_tag
+#
+#     async def recv(self, tag=ANY_TAG):
+#         if self.buffer is None:
+#             if self._buffer_task is not None and self._buffer_task.done():
+#                 await self._buffer_task
+#                 self._buffer_task = None
+#             if self._buffer_task is None:
+#                 self._buffer_task = asyncio.create_task(self.set_buffer())
+#             try:
+#                 # "shield" the task to prevent it from being cancelled.
+#                 # The cancel happens, when the user used recv with
+#                 # ANY_SOURCE and another rank was faster to send the data.
+#                 await asyncio.shield(self._buffer_task)
+#             except asyncio.CancelledError:
+#                 raise asyncio.CancelledError(self._buffer_task)
+#                 raise TagError('Cancelled')
+#             except EOFError:
+#                 self._buffer_task = None
+#                 raise TagError('EOF')
+#             self._buffer_task = None
+#
+#         if self.buffer is None:
+#             raise TagError('Other side closed the socket')
+#
+#         data, msg_tag = self.buffer
+#         self.buffer = None
+#
+#         if not tag_match(msg_tag, tag):
+#                 self.buffer = data, msg_tag
+#                 raise TagError(f'{self.depth} Expected tag {tag}, got {msg_tag}')
+#
+#         # print(f'{self.depth} {c.magenta}recv{c.reset} {self._decode(data)!r} from {self.rank} with tag {msg_tag}')
+#         return self.backend._loads(data), msg_tag
+
+
+class ABCBackend:
+    """
+    This class implements the actual communication between two processes.
+
+    """
+    def __init__(self, reader, writer, depth, rank):
+        self.reader = reader
+        self.writer = writer
+        self.depth = depth
+        self.rank = rank
+
+        self.p2p = P2P(reader, writer, depth=depth, rank=rank)
+
+    def _loads(self, data):
+        raise NotImplementedError
+
+    def _dumps(self, data):
+        raise NotImplementedError
+
+    async def dump(self, data, tag):
+        # if _DEBUG:
+        #     print(f'{self.__class__.__name__} (D{self.depth}, R{RANK}):  dump {data!r} T{tag}', flush=True)
+
+        data = self._dumps(data)
+        await self.p2p.send(data, tag)
+
+        # header = struct.pack(
+        #     'ii',
+        #     len(data),  # MPI is also limited to 2GB
+        #     tag,
+        # )
+        # self.writer.write(header)
+        # self.writer.write(data)
+        # await self.wait_for(self.writer.drain())
+
+        # if _DEBUG:
+        #     print(f'{self.__class__.__name__} (D{self.depth}, R{RANK}):  dumped {data!r} T{tag}', flush=True)
+
+    # class Loader:
+    #     def __init__(self, tag, deserializer, reader):
+    #         self.tag = tag
+    #         self.trigger = asyncio.Event()
+    #         self.deserializer = deserializer
+    #         self.reader = reader
+    #
+    #     @property
+    #     def tag(self):
+    #         return self._tag
+    #
+    #     @tag.setter
+    #     def tag(self, value):
+    #         self._tag = value
+    #         self.trigger.set()
+    #
+    #     async def load(self):
+    #         header = await _debug_wait_for(self.reader.read(8))
+    #         if not header:
+    #             raise EOFError('EOF', header)
+    #             # raise RuntimeError('EOF', header)
+    #
+    #         length, tag = struct.unpack('ii', header)
+    #         data = await _debug_wait_for(self.reader.read(length))
+    #
+    #         return self.deserializer(data), tag
+    #
+    #     async def get(self):
+    #         self.trigger.clear()
+    #         obj, tag = await self.load()
+    #
+    #         assert tag != ANY_TAG, tag
+    #
+    #         if self.tag != ANY_TAG:
+    #             if tag != self.tag:
+    #                 await self.trigger.wait()
+    #                 self.trigger.clear()
+
+    async def load(self, tag=ANY_TAG):
+        # if _DEBUG:
+        #     print(f'{self.__class__.__name__} (D{self.depth}, R{RANK}):  load', flush=True)
+
+        self.p2p.recv_tag = tag
+        data, tag = await self.p2p.recv()
+
+        # header = await self.wait_for(self.reader.read(8))
+        # if not header:
+        #     raise EOFError('EOF', header)
+        #     # raise RuntimeError('EOF', header)
+        #
+        # length, tag = struct.unpack('ii', header)
+        # data = await self.wait_for(self.reader.read(length))
+
+        # if _DEBUG:
+        #     print(f'{self.__class__.__name__} (D{self.depth}, R{RANK}):  loaded {data!r} T{tag}', flush=True)
+
+        return self._loads(data), tag
+
+
+class PickleBackend:#(ABCBackend):
+    def _loads(self, data):
+        return pickle.loads(data)
+
+    def _dumps(self, data):
+        return pickle.dumps(data)
+
+
+class JsonBackend:#(ABCBackend):
+    def _loads(self, data):
+        data = data.decode()
+        try:
+            return json.loads(data)
+        except json.JSONDecodeError:
+            raise ValueError(f'Could not decode {data}')
+
+    def _dumps(self, data):
+        return json.dumps(data).encode()
+
+
+
+async def establish_connection(
+        # runner,
+        *,
+        depth,
+        host=_HOST,  # IP of rank 0
+        port=_PORT,  # port of rank 0
+        rank=RANK,  # rank of this process
+        size=SIZE,
+        debug=DEBUG,
+):
+    rank_to_p2p = Dispatcher()
+    if rank == 0:
+        finished_setup = asyncio.Event()
+
+        async def handle_request(reader: asyncio.StreamReader, writer: asyncio.StreamWriter):
+            if debug:
+                info(f'{depth} Connection from {writer.get_extra_info("peername")}')
+
+            assert len(rank_to_p2p) < size, f'All ranks already connected. {rank_to_p2p}'
+
+            # rank = await reader.read(1024)
+            # # Always use json for first message. That minimizes the security risk.
+            p2p = P2Pv2(reader, writer, depth=depth, rank='unknown', debug=debug)
+            if debug:
+                info(f'{depth} from {rank} data: Created P2Pv2 object')
+            other_rank = await p2p.recv()
+            if debug:
+                info(f'{depth} from {rank} data: Received {other_rank}')
+            addr = writer.get_extra_info('peername')
+
+            if debug:
+                info(f'{depth} from {rank} data: Received {other_rank} from {addr}')
+
+            assert other_rank not in rank_to_p2p, f'Rank {other_rank} already exists. {rank_to_p2p}'
+            p2p.backend = 'pickle'
+            rank_to_p2p[other_rank] = p2p
+
+            if len(rank_to_p2p) == size - 1:
+                if debug:
+                    info(f'{depth} All ranks connected')
+                finished_setup.set()
+
+        task = None
+        # async def setup():
+        if size > 1:
+            # nonlocal task
+            server = await asyncio.start_server(
+                handle_request, host, port)
+
+            addr = server.sockets[0].getsockname()
+            if debug:
+                info(f'Serving on {addr} ({depth})')
+
+            task = asyncio.create_task(server.serve_forever())
+
+            await finished_setup.wait()
+            task.cancel()
+
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+                # print("main(): cancel_me is cancelled now")
+
+            # return server
+
+        # if size > 1:
+        #     runner.run(setup())
+            # runner.run(finished_setup.wait())
+
+    else:
+        # async def connect():
+        i = 0
+        while True:
+            i += 1
+            try:
+                reader, writer = await asyncio.open_connection(host, port)
+                p2p = P2Pv2(reader, writer, depth=depth, rank='unknown (actually 0)', debug=debug)
+                await p2p.send(rank, 0)
+                # writer.write(JsonBackend().dumps(RANK))
+                if debug:
+                    info(f'Connected to server from {rank}. ({depth})')
+
+                # data = await reader.read(100)
+                # print(f'Received: {backend.loads(data)}')
+
+                p2p.backend = 'pickle'
+                rank_to_p2p[0] = p2p
+                break
+            except ConnectionRefusedError:
+                # 1h -> 3600 s / 0.1 ms = 36000
+                # 5 min -> 300 s / 0.1 ms = 3000
+                if i > 3000:
+                    raise
+                if i > 10:
+                    info(f'Failed to connect, retrying in 0.1s ({depth})')
+                await asyncio.sleep(0.1)
+                continue
+
+        # rank_to_p2p[0] = runner.run(connect()) #  P2P(*runner.run(connect()), depth=depth, rank=0, backend=backend)
+
+    return rank_to_p2p

--- a/dlp_mpi/ame/core/con_v2.py
+++ b/dlp_mpi/ame/core/con_v2.py
@@ -7,7 +7,16 @@ import types
 import asyncio
 import time
 
-from paderbox.utils.mapping import Dispatcher
+try:
+    from paderbox.utils.mapping import Dispatcher  # better error message
+except ImportError:
+    class Dispatcher(dict):
+        def __getitem__(self, key):
+            try:
+                return super().__getitem__(key)
+            except KeyError:
+                raise KeyError(f'{key!r}. Available keys: {list(self.keys())}')
+
 
 from ..constants import *
 from .logger import info

--- a/dlp_mpi/ame/core/con_v3.py
+++ b/dlp_mpi/ame/core/con_v3.py
@@ -408,8 +408,12 @@ def authenticate_server_side(sock: socket.socket, authkey, version=_AUTH_VERSION
     ...         s1, s2 = socket.socketpair(socket.AF_UNIX)
     ...         future = executor.submit(authenticate_client_side, s2, b'123', version)
     ...         print('Server', authenticate_server_side(s1, b'123', version))
+    ...         time.sleep(0.01)  # Give the client some time to recv the last msg.
     ...         _ = s1.close(), s2.close()
-    ...         print('Client', future.result())
+    ...         try:
+    ...             print('Client', future.result())
+    ...         except Exception as e:
+    ...             print('Client', e)
     >>> test(version=1)
     Server True
     Client None
@@ -425,6 +429,7 @@ def authenticate_server_side(sock: socket.socket, authkey, version=_AUTH_VERSION
     ...         s1, s2 = socket.socketpair(socket.AF_UNIX)
     ...         future = executor.submit(authenticate_client_side, s2, b'323', version)
     ...         print('Server', authenticate_server_side(s1, b'123', version))
+    ...         time.sleep(0.01)  # Give the client some time to recv the last msg.
     ...         _ = s1.close(), s2.close()
     ...         try:
     ...             print('Client', future.result())

--- a/dlp_mpi/ame/core/con_v3.py
+++ b/dlp_mpi/ame/core/con_v3.py
@@ -1,0 +1,498 @@
+"""
+I wrote this code while reading the following tutorial:
+https://realpython.com/python-sockets/#echo-client-and-server
+Hence, some code has its origin in the tutorial.
+
+
+"""
+import os
+import pickle
+import struct
+import time
+import selectors
+import socket
+import base64
+import hashlib
+import types
+
+from ..constants import *
+from .logger import info
+
+
+class SocketClosed(Exception):
+    pass
+
+
+class Mixin:
+    def __init__(self, host, port, rank, size, debug=False):
+        self.host = host
+        self.port = port
+        self.rank = rank
+        self.size = size
+        self.debug = debug
+
+    # @staticmethod
+    # def _msg_recv(sock, length):
+    #     chunks = []
+    #     remaining = length
+    #     while remaining > 0:
+    #         chunk = sock.recv(min(remaining, 65536))
+    #         if not chunk:
+    #             raise SocketClosed("Socket closed")
+    #         chunks.append(chunk)
+    #         remaining -= len(chunk)
+    #     return b''.join(chunks)
+
+    # Not sure, what the optimal buffer size would be.
+    _MAX_RECV = 65536  # = 2**16
+    # _MAX_RECV = 1048576  # = 2**20
+    # _MAX_RECV = 16777216  # = 2**24  # With this, get many packages of length 65483
+
+    @classmethod
+    def recv_nbytes(cls, sock: 'socket.SocketType', length):
+        read = 0
+        try:
+            view = memoryview(bytearray(length))
+            while length:
+                recv_length = sock.recv_into(view[read:], min(length, cls._MAX_RECV))
+                if recv_length == 0:
+                    raise SocketClosed("Socket closed")
+                length -= recv_length
+                read += recv_length
+            return view.tobytes()  # convert to bytes
+        except KeyboardInterrupt as e:
+            raise KeyboardInterrupt(f"Waiting for {length} more bytes. Got {read} bytes.") from e
+
+    _HEADER_FMT = 'Qi'
+    _HEADER_FMT_SIZE = struct.calcsize(_HEADER_FMT)
+    # i int (4 bytes)
+    # I unsigned int (4 bytes)
+    # q long long (8 bytes)
+    # Q unsigned long long (8 bytes)
+
+    @classmethod
+    def msg_recv(cls, sock):
+        length, tag = struct.unpack(cls._HEADER_FMT, cls.recv_nbytes(sock, cls._HEADER_FMT_SIZE))
+        if tag not in [BARRIER_TAG]:
+            data = pickle.loads(cls.recv_nbytes(sock, length))
+        else:
+            data = None
+        return data, tag
+
+    @classmethod
+    def msg_send(cls, sock, tag, data):
+        if tag not in [BARRIER_TAG]:
+            b = pickle.dumps(data)
+            try:
+                msg = struct.pack(cls._HEADER_FMT, len(b), tag)
+                assert len(msg) == cls._HEADER_FMT_SIZE, (len(msg), cls._HEADER_FMT_SIZE)
+                sock.sendall(msg)
+            except struct.error as e:
+                raise RuntimeError(f"Could not sendall(struct.pack('ii', {len(b)}, {tag}))") from e
+            sock.sendall(b)
+        else:
+            assert data is None, (data, tag)
+            sock.sendall(struct.pack(cls._HEADER_FMT, 0, tag))
+
+
+class Rootv3(Mixin):
+    def __init__(self, sel, socks, host, port, rank, size, debug=False):
+        super().__init__(host, port, rank, size, debug)
+        self.sel = sel
+        self.socks = socks
+
+    def __del__(self):
+        self.sel.close()
+
+    def send(self, data, dest, tag=ANY_TAG):
+        if isinstance(dest, int):
+            dest = {dest}
+        elif isinstance(dest, (tuple, list, set)):
+            # broadcast
+            dest = set(dest)
+            assert all(isinstance(i, int) for i in dest), dest
+        else:
+            raise TypeError(dest, type(dest))
+
+        while dest:
+            events = self.sel.select(timeout=None)
+            for key, mask in events:
+                if key.data is None:
+                    raise Exception('Got unexpected connection', key, mask)
+                else:
+                    if mask & selectors.EVENT_READ:
+                        pass
+                    if mask & selectors.EVENT_WRITE:
+                        if key.data.rank in dest:
+                            dest.remove(key.data.rank)
+                            self.msg_send(key.fileobj, tag, data)
+                if not dest:
+                    break
+
+    def recv(self, source=ANY_SOURCE, tag=ANY_TAG, status=None):
+        assert tag == ANY_TAG, (tag, f'Only ANY_TAG ({ANY_SOURCE}) is supported. Not {tag}')
+
+        if isinstance(source, int):
+            pass
+        elif isinstance(source, (tuple, list, set)):
+            # gather
+            source = set(source)
+            assert all(isinstance(i, int) and source != ANY_SOURCE for i in source), source
+            assert status is None, status
+        else:
+            raise TypeError(source, type(source))
+
+        datas = {}
+        while isinstance(source, int) or source:
+            events = self.sel.select(timeout=None)
+            for key, mask in events:
+                if key.data is None:
+                    raise Exception('Got unexpected connection', key, mask)
+                else:
+                    if mask & selectors.EVENT_READ:
+                        if ANY_SOURCE == source or key.data.rank == source or key.data.rank in source:
+                            try:
+                                data, msg_tag = self.msg_recv(key.fileobj)
+                            except SocketClosed:
+                                if source != ANY_SOURCE:
+                                    raise
+                                # The other side closed the socket.from
+                                # That can happen, when the source is ANY_SOURCE,
+                                # i.e. one RANK has finished, while others are still running.
+                                self.sel.unregister(key.fileobj)
+                                key.fileobj.close()
+                                del self.socks[key.data.addr]
+                                assert len(self.socks) > 0, self.socks
+                                continue
+
+                            if ANY_SOURCE == source or key.data.rank == source:
+                                if status:
+                                    status.source = key.data.rank
+                                    status.tag = msg_tag
+                                return data
+                            else:
+                                source.remove(key.data.rank)
+                                datas[key.data.rank] = data
+                    if mask & selectors.EVENT_WRITE:
+                        pass
+                if isinstance(source, set) and len(source) == 0:
+                    break
+        return datas
+
+
+class Clientv3(Mixin):
+    def __init__(self, sock, host, port, rank, size, debug=False):
+        super().__init__(host, port, rank, size, debug)
+        self.sock = sock
+
+    def __del__(self):
+        self.sock.close()
+
+    def send(self, obj, dest, tag=ANY_TAG):
+        assert dest == 0, dest
+        return self.msg_send(self.sock, tag, obj)
+
+    def recv(self, source=ANY_SOURCE, tag=ANY_TAG, status=None):
+        assert tag == ANY_TAG, (tag, f'Only ANY_TAG ({ANY_SOURCE}) is supported. Not {tag}')
+        assert source in [0, ANY_SOURCE], source
+
+        data, msg_tag = self.msg_recv(self.sock)
+        if status:
+            status.source = 0
+            status.tag = msg_tag
+
+        return data
+
+
+class _Socket:
+    def __init__(self, s):
+        self.s = s
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.s.close()
+
+    def connect(self, *args):
+        return self.s.connect(*args)
+
+    def sendall(self, bytes):
+        info(f"sendall {bytes} (len: {len(bytes)})", frames=2)
+        return self.s.sendall(bytes)
+
+    def recv(self, *args):
+        r = self.s.recv(*args)
+        info(f"recv {r}", frames=2)
+        return r
+
+    def fileno(self):
+        return self.s.fileno()
+
+    def close(self):
+        return self.s.close()
+
+    def recv_into(self, buffer: memoryview, nbytes=None):
+        r = self.s.recv_into(buffer=buffer, nbytes=nbytes)
+        info(f"{r} = recv_into {buffer.tobytes()[:r]} {nbytes}", frames=2)
+        return r
+
+
+def establish_connection_v3(host, port, rank, size, *, authkey, debug=False) -> 'Rootv3|Clientv3':
+    if size < 200:
+        fmt = 'B'  # limited to 256 processes
+    else:
+        fmt = 'H'  # limited to 65536 processes
+    fmt_len = struct.calcsize(fmt)
+
+    try:
+        _ = struct.pack(fmt, size)  # Fail early if size is not a compatible type
+    except Exception:
+        raise RuntimeError(f"Size {size} ({type(size)}) is not a compatible type for struct.unpack({fmt!r}, size)")
+
+    if rank == 0:
+        sel = selectors.DefaultSelector()
+        lsock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        try:
+            lsock.bind((host, port))
+        except Exception:
+            for k, v in os.environ.items():
+                if 'port' in k.lower():
+                    print(k, v)
+            raise Exception(f"Could not bind to {(host, port)}")
+        lsock.listen()
+        # lsock.setblocking(False)  # We don't need the non-blocking behaviour.
+        sel.register(lsock, selectors.EVENT_READ, data=None)
+
+        try:
+            # ToDo: Remove connected dict. It is not nessesary.
+            connected = {}
+            while True:
+                events = sel.select(timeout=None)
+                for key, mask in events:
+                    if key.data is None:
+                        conn, addr = key.fileobj.accept()
+                        # conn.setblocking(False)
+                        data = types.SimpleNamespace(addr=addr, rank=None, size=size)
+                        events = selectors.EVENT_READ | selectors.EVENT_WRITE
+                        if debug:
+                            conn = _Socket(conn)
+                        sel.register(conn, events, data=data)
+                    else:
+                        if mask & selectors.EVENT_READ:
+                            if key.data.addr not in connected:
+                                other_rank, = struct.unpack(fmt, Mixin.recv_nbytes(key.fileobj, fmt_len))
+                                if authenticate_server_side(key.fileobj, authkey):
+                                    key.data.rank = other_rank
+                                    connected[key.data.addr] = (other_rank, key.fileobj)
+                                else:
+                                    # print(f"Rank {rank} got wrong authkey from {key.data.addr}. Ignore connection. {outer_authkey} != {authkey}")
+                                    pass
+                        elif mask & selectors.EVENT_WRITE:
+                            pass
+                        else:
+                            raise Exception('Got unexpected mask', mask, 'cannot happen.')
+
+                if len(connected) == size - 1:
+                    return Rootv3(sel, dict(connected), host, port, rank, size, debug)
+
+        except KeyboardInterrupt:
+            raise
+    else:
+        for trial in range(100):
+            try:
+                s = socket.socket(socket.AF_INET, socket.SOCK_STREAM).__enter__()
+
+                if debug:
+                    s = _Socket(s)
+
+                try:
+                    s.connect((host, port))
+                    s.sendall(struct.pack(fmt, rank))
+                    authenticate_client_side(s, authkey)
+                except BaseException:
+                    s.__exit__(None, None, None)
+                    raise
+                return Clientv3(s, host, port, rank, size, debug)
+            except ConnectionRefusedError as e:
+                if trial < 10:
+                    time.sleep(0.01)
+                elif trial < 20:
+                    time.sleep(0.1)
+                elif trial < 30:
+                    if debug:
+                        info(f"{rank} Could not connect to {host}:{port}. Try again in 1s")
+                    time.sleep(1)
+                elif trial < 40:
+                    # This is serious, hence do the prints also without debug flag.
+                    info(f"{rank} Could not connect to {host}:{port}. Try again in 10s")
+                    time.sleep(10)
+                else:
+                    raise
+
+
+class _DoctestSocket:
+    def __init__(self, other):
+        self.other = other
+        self.queue = b''
+
+    def sendall(self, data):
+        self.other.queue += data
+
+    def recv(self, n):
+        for i in range(100):
+            if self.queue:
+                data = self.queue[:n]
+                self.queue = self.queue[len(data):]
+                return data
+            time.sleep(0.01)
+        raise RuntimeError("Timeout")
+
+    def recv_into(self, buffer, nbytes=None):
+        data = self.recv(nbytes)
+        buffer[:len(data)] = data
+        return len(data)
+
+    def close(self):
+        pass
+
+
+def _doctext_socket_pair():
+    a = _DoctestSocket(None)
+    b = _DoctestSocket(a)
+    a.other = b
+    return a, b
+
+
+_AUTH_VERSION = 3
+
+
+def authenticate_server_side(sock: socket.socket, authkey, version=_AUTH_VERSION):
+    """
+    Versions:
+     - 1: Send authkey from client to server.
+     - 2: Send a challenge from server to client. Client has to respond with a
+          hash of the challenge and the authkey.
+     - 3: Like 2, but additionally, the client has to send a challenge to the
+          server. So the server knowns that the client has the correct authkey
+          and the client knows that the server has the correct authkey.
+
+    >>> import threading
+    >>> # s1, s2 = _doctext_socket_pair()
+    >>> s1, s2 = socket.socketpair(socket.AF_UNIX)
+    >>> t = threading.Thread(target=authenticate_client_side, args=(s2, b'123', 1))
+    >>> t.start()
+    >>> authenticate_server_side(s1, b'123', 1)
+    True
+    >>> s1.close(), s2.close()
+    (None, None)
+
+    >>> import threading
+    >>> # s1, s2 = _doctext_socket_pair()
+    >>> s1, s2 = socket.socketpair(socket.AF_UNIX)
+    >>> t = threading.Thread(target=authenticate_client_side, args=(s2, b'123', 2))
+    >>> t.start()
+    >>> authenticate_server_side(s1, b'123', 2)
+    True
+    >>> s1.close(), s2.close()
+    (None, None)
+
+    >>> import threading
+    >>> # s1, s2 = _doctext_socket_pair()
+    >>> s1, s2 = socket.socketpair(socket.AF_UNIX)
+    >>> t = threading.Thread(target=authenticate_client_side, args=(s2, b'123', 3))
+    >>> t.start()
+    >>> authenticate_server_side(s1, b'123', 3)
+    True
+    >>> s1.close(), s2.close()
+    (None, None)
+
+    >>> # s1, s2 = _doctext_socket_pair()
+    >>> s1, s2 = socket.socketpair(socket.AF_UNIX)
+    >>> t = threading.Thread(target=authenticate_client_side, args=(s2, b'323', 1))
+    >>> t.start()
+    >>> authenticate_server_side(s1, b'123', 1)  # doctest: +ELLIPSIS
+    Authkey mismatch for hostname '': b... != b...
+    False
+    >>> s1.close(), s2.close()
+    (None, None)
+
+    >>> # s1, s2 = _doctext_socket_pair()
+    >>> s1, s2 = socket.socketpair(socket.AF_UNIX)
+    >>> t = threading.Thread(target=authenticate_client_side, args=(s2, b'323', 2))
+    >>> t.start()
+    >>> authenticate_server_side(s1, b'123', 2)  # doctest: +ELLIPSIS
+    Authkey mismatch for hostname '': b... != b...
+    False
+    >>> s1.close(), s2.close()
+    (None, None)
+
+    >>> # s1, s2 = _doctext_socket_pair()
+    >>> s1, s2 = socket.socketpair(socket.AF_UNIX)
+    >>> t = threading.Thread(target=authenticate_client_side, args=(s2, b'323', 3))
+    >>> t.start()
+    >>> authenticate_server_side(s1, b'123', 3)  # doctest: +ELLIPSIS
+    Authkey mismatch for hostname '': b... != b...
+    False
+    >>> s1.close(), s2.close()
+    (None, None)
+    """
+    if version == 1:
+        outer_authkey = Mixin.recv_nbytes(sock, len(authkey))
+        if authkey != outer_authkey:
+            print(f'Authkey mismatch for hostname {sock.getpeername()!r}: {authkey} != {outer_authkey}')
+            return False
+        return True
+    elif version == 2:
+        challenge = os.urandom(16)
+        sock.sendall(challenge)
+        expected_response = hashlib.sha256(challenge + authkey).digest()
+        response = Mixin.recv_nbytes(sock, len(expected_response))
+        if response != expected_response:
+            print(f'Authkey mismatch for hostname {sock.getpeername()!r}: {response} != {expected_response}')
+            return False
+        return True
+    elif version == 3:
+        c = Challenge(authkey, sock)
+        if c.challenger():
+            c.challenged()
+            return True
+        return False
+    else:
+        raise ValueError(f"Unknown auth version: {version}")
+
+
+def authenticate_client_side(sock, authkey, version=_AUTH_VERSION):
+    if version == 1:
+        sock.sendall(authkey)
+    elif version == 2:
+        challenge = Mixin.recv_nbytes(sock, 16)
+        response = hashlib.sha256(challenge + authkey).digest()
+        sock.sendall(response)
+    elif version == 3:
+        c = Challenge(authkey, sock)
+        c.challenged()
+        if c.challenger():
+            return True
+        return False
+    else:
+        raise ValueError(f"Unknown auth version: {version}")
+
+
+class Challenge:
+    def __init__(self, authkey, sock):
+        self.authkey = authkey
+        self.sock = sock
+
+    def challenger(self):
+        challenge = os.urandom(16)
+        response = hashlib.sha256(challenge + self.authkey).digest()
+
+        self.sock.sendall(challenge)
+        recv_response = Mixin.recv_nbytes(self.sock, len(response))
+        if recv_response != response:
+            print(f'Authkey mismatch for hostname {self.sock.getpeername()!r}: {recv_response} != {response}')
+            return False
+        return True
+
+    def challenged(self):
+        challenge = Mixin.recv_nbytes(self.sock, 16)
+        response = hashlib.sha256(challenge + self.authkey).digest()
+        self.sock.sendall(response)

--- a/dlp_mpi/ame/core/core_v2.py
+++ b/dlp_mpi/ame/core/core_v2.py
@@ -5,9 +5,9 @@ import json
 import pickle
 
 
-from ame.core.constants import *
-from ame.core.con_v2 import P2Pv2, establish_connection
-from ame.core.logger import info
+from dlp_mpi.ame.constants import *
+from dlp_mpi.ame.core.con_v2 import P2Pv2, establish_connection
+from dlp_mpi.ame.core.logger import info
 # from ame.core.con import establish_connection_v3
 
 
@@ -50,10 +50,10 @@ class Communicator_v2:
     def __init__(
             self,
             *,
-            rank=RANK,
-            size=SIZE,
-            port=_PORT,
-            host=_HOST,
+            rank,
+            size,
+            port,
+            host,
             _runner=None,
             _depth=0,
             debug=DEBUG,
@@ -236,8 +236,8 @@ class Communicator_v2:
 
 Communicator = Communicator_v2
 
-try:
-    COMM_WORLD = Communicator(rank=RANK, size=SIZE)
-    COMM = COMM_WORLD
-except Exception:
-    raise RuntimeError(RANK, SIZE)
+# try:
+#     COMM_WORLD = Communicator(rank=RANK, size=SIZE)
+#     COMM = COMM_WORLD
+# except Exception:
+#     raise RuntimeError(RANK, SIZE)

--- a/dlp_mpi/ame/core/core_v2.py
+++ b/dlp_mpi/ame/core/core_v2.py
@@ -1,0 +1,243 @@
+import functools
+import os
+import asyncio
+import json
+import pickle
+
+
+from ame.core.constants import *
+from ame.core.con_v2 import P2Pv2, establish_connection
+from ame.core.logger import info
+# from ame.core.con import establish_connection_v3
+
+
+# backend = 'json'
+backend = 'pickle'
+
+__all__ = [
+    'COMM_WORLD',
+    # 'RANK',
+    # 'SIZE',
+    'Status',
+]
+
+
+class c:
+    red = '\033[91m'
+    green = '\033[92m'
+    yellow = '\033[93m'
+    blue = '\033[94m'
+    magenta = '\033[95m'
+    cyan = '\033[96m'
+    reset = '\033[0m'
+
+
+class Status:
+    def __init__(self):
+        self.source: int = None
+        self.tag: int = None
+
+
+
+class Communicator_v2:
+    # size = SIZE
+    # rank = RANK
+    # Barrier = lambda self: None
+    # bcast = lambda self, data, *args, **kwargs: data
+    # gather = lambda self, data, *args, **kwargs: [data]
+    # Clone = lambda self: self
+
+    def __init__(
+            self,
+            *,
+            rank=RANK,
+            size=SIZE,
+            port=_PORT,
+            host=_HOST,
+            _runner=None,
+            _depth=0,
+            debug=DEBUG,
+    ):
+        self.rank = rank
+        self.size = size
+
+        self._debug = debug
+        self._host = host
+        self._port = port
+
+        self._depth = _depth
+        if _runner is None:
+            from ame.backport_runner import Runner
+            self._runner = Runner()
+            self._runner.__enter__()
+        else:
+            self._runner = _runner
+        info(f'{self._depth} Runner: {self._runner}, {id(self._runner)} {RANK}')
+
+        if self.size > 1:
+            self._rank_to_p2p = self._runner.run(
+                establish_connection(
+                    depth=self._depth, rank=self.rank, size=self.size, host=self._host, port=self._port,
+                    debug=self._debug,
+                )
+            )
+            self._loop = self._runner.get_loop()
+            info(f'{self._depth} Loop: {self._loop}')
+        else:
+            self._rank_to_p2p = {}
+
+        assert self.rank < self.size, (self.rank, self.size)
+
+    def __del__(self):
+        # if self._debug:
+        #     info(f'{self._depth} __del__')
+
+        pass
+
+        # if hasattr(self, '_rank_to_p2p'):
+
+            # for k, v in self._rank_to_p2p.items():
+            #     v.writer.close()
+
+        #     async def shutdown_p2p():
+        #         for k, v in self._rank_to_p2p.items():
+        #             await v.shutdown()
+        #     # self._runner._loop.create_task(shutdown_p2p())
+        #
+        #
+        #
+        #     info(f'{self._depth} Loop: {self._runner._loop}, {self._runner}, {RANK}, {id(self._runner)}, {id(self._runner._loop)}')
+        #     # if self._runner._loop is not None:
+        #     if self._runner._loop.is_closed():
+        #         info(f'Issue: Loop is closed')
+        #
+        #         # for k, v in self._rank_to_p2p.items():
+        #         #     if v._buffer_task:
+        #         #         v._buffer_task._log_destroy_pending = False
+        #         # Process shutting down. The loop is already closed,
+        #         # hence we cannot run the shutdown_p2p coroutine.
+        #
+        #         # for k, v in self._rank_to_p2p.items():
+        #         #     self._shutdown = True
+        #         #     if v._buffer_task:
+        #         #         v._buffer_task.cancel()
+        #         #         # await self._buffer_task
+        #         #     v.writer.close()
+        #     else:
+        #         pass
+        #         # pass
+        #         # asyncio.create_task()
+        #
+        #         # self._runner.run(shutdown_p2p())
+        #
+        # if self._debug:
+        #     info(f'{self._depth} __del__ finished')
+
+    def clone(self):
+        return self.__class__(
+            rank=self.rank,
+            size=self.size,
+            port=self._port,
+            host=self._host,
+            _runner=self._runner,
+            _depth=self._depth + 1,
+        )
+
+    def send(self, obj, dest, tag=0):
+        self._runner.run(self._send(obj, dest, tag))
+
+    async def _send(self, obj, dest, tag=0):
+        assert dest == 0 or self.rank == 0, f'Communication only supported with rank 0, not {self.rank} to {dest}'
+        await self._rank_to_p2p[dest].send(obj, tag)
+
+    def recv(self, source=ANY_SOURCE, tag=ANY_TAG, status=None):
+        return self._runner.run(self._recv(source=source, tag=tag, status=status))
+
+    async def _recv(self, source, tag=ANY_TAG, status=None):
+        if source == ANY_SOURCE:
+            async def task_fn(i):
+                return i, await self._rank_to_p2p[i].ready(tag=tag)
+
+            tasks = [
+                asyncio.create_task(task_fn(i))
+                for i in range(0, self.size)
+                if i != self.rank
+            ]
+            while tasks:
+                finished, unfinished = await asyncio.wait(
+                    tasks, return_when=asyncio.FIRST_COMPLETED)
+
+                for x in finished:
+                    i, result = x.result()
+
+                    if result:
+                        # cancel the other tasks, we have a result. We need to wait for the cancellations
+                        # to propagate.
+                        for task in unfinished:
+                            task.cancel()
+                        await asyncio.wait(unfinished)
+
+                        return await self._rank_to_p2p[i].get_data(tag=tag,
+                                                                   status=status)
+
+                tasks = unfinished
+            raise RuntimeError(
+                f'Go no message with the requested tag: {tag}. Got ')
+        else:
+            return await self._rank_to_p2p[source].recv(tag=tag)
+
+    def bcast(self, obj, root=0):
+        return self._bcast(obj, root)
+
+    def _bcast(self, obj, root=0, tag=BCAST_TAG):
+        assert root == 0 or self.rank == 0, f'Communication only supported with rank 0, not {self.rank} to {root}'
+        if self.rank == root:
+            async def dummy_fn():
+                await asyncio.gather(*[
+                    self._send(obj, i, tag)
+                    for i in range(1, self.size)
+                ])
+
+            self._runner.run(dummy_fn())
+            return obj
+        else:
+            return self.recv(root, tag=tag)
+
+    def gather(self, obj, root=0):
+        return self._gather(obj, root)
+
+    def _gather(self, obj, root=0, tag=GATHER_TAG):
+        assert root == 0 or self.rank == 0, f'Communication only supported with rank 0, not {self.rank} to {root}'
+        if self.rank == root:
+
+            async def dummy_fn():
+                ret = await asyncio.gather(*[
+                    self._recv(i, tag=tag)
+                    for i in range(1, self.size)
+                    if i != root
+                ])
+                if self._debug:
+                    info(f'{self._depth} {ret}')
+                ret.insert(root, obj)
+                return ret
+            return self._runner.run(dummy_fn())
+        else:
+            self.send(obj, root, tag)
+            return None
+
+    def barrier(self):
+        self._bcast(None, tag=BARRIER_TAG)
+        self._gather(None, tag=BARRIER_TAG)
+
+    Barrier = barrier
+    Clone = clone
+
+
+
+Communicator = Communicator_v2
+
+try:
+    COMM_WORLD = Communicator(rank=RANK, size=SIZE)
+    COMM = COMM_WORLD
+except Exception:
+    raise RuntimeError(RANK, SIZE)

--- a/dlp_mpi/ame/core/core_v3.py
+++ b/dlp_mpi/ame/core/core_v3.py
@@ -36,6 +36,9 @@ class Communicator_v3:
             depth=0,
             debug=DEBUG,
     ):
+        assert isinstance(rank, int), (rank, type(rank))
+        assert isinstance(size, int), (size, type(size))
+
         self.rank = rank
         self.size = size
 
@@ -138,6 +141,7 @@ Communicator = Communicator_v3
 #
 #
 # MPI = _MPI()
+
 
 from ._init.get_init import get
 # _HOST, _PORT, RANK, SIZE, AUTHKEY = get()

--- a/dlp_mpi/ame/core/core_v3.py
+++ b/dlp_mpi/ame/core/core_v3.py
@@ -1,0 +1,150 @@
+from ..constants import *
+from .logger import info
+from .con_v3 import establish_connection_v3, Clientv3, Rootv3
+
+
+__all__ = [
+    'COMM_WORLD',
+    'Status',
+]
+
+
+class c:
+    red = '\033[91m'
+    green = '\033[92m'
+    yellow = '\033[93m'
+    blue = '\033[94m'
+    magenta = '\033[95m'
+    cyan = '\033[96m'
+    reset = '\033[0m'
+
+
+class Status:
+    def __init__(self):
+        self.source: int = None
+        self.tag: int = None
+
+
+class Communicator_v3:
+    def __init__(
+            self,
+            rank,
+            size,
+            port,
+            host,
+            authkey,
+            depth=0,
+            debug=DEBUG,
+    ):
+        self.rank = rank
+        self.size = size
+
+        self._depth = depth
+        self._debug = debug
+        self._host = host
+        self._port = port
+        self._authkey = authkey
+
+        if self.size > 1:
+            assert isinstance(port, int), (port, type(port))
+            self._con: 'Clientv3 | Rootv3' = establish_connection_v3(
+                host=host,
+                port=port,
+                rank=rank,
+                size=size,
+                authkey=authkey,
+                debug=debug,
+            )
+        else:
+            class DummyCon:
+                def send(self, obj, dest, tag=0):
+                    # Dummy implementation for bcast
+                    assert dest == [], dest
+
+                def recv(self, source, tag=ANY_TAG, status=None):
+                    # Dummy implementation for gather
+                    assert source == [], source
+                    return {}
+            self._con: 'Clientv3 | Rootv3' = DummyCon()
+
+    def send(self, obj, dest, tag=0):
+        assert isinstance(dest, int), (dest, type(dest))
+        self._con.send(obj, dest, tag)
+
+    def recv(self, source=ANY_SOURCE, tag=ANY_TAG, status=None):
+        assert isinstance(source, int), (source, type(source))
+        return self._con.recv(source, tag, status)
+
+    def bcast(self, obj, root=0, _tag=BCAST_TAG):
+        if self.rank == root:
+            dest = [i for i in range(self.size) if i != root]
+            self._con.send(obj, dest, tag=_tag)
+            return obj
+        else:
+            return self._con.recv(source=root)
+
+    def gather(self, obj, root=0, _tag=GATHER_TAG):
+        if self.rank == root:
+            source = [i for i in range(self.size) if i != root]
+            ret = self._con.recv(source)
+            ret = [
+                ret[i] if i != root else obj
+                for i in range(0, self.size)
+            ]
+            return ret
+        else:
+            self._con.send(obj, root, tag=_tag)
+            return None
+
+    def barrier(self):
+        # Note: This is a naive implementation.
+        #       The BARRIER_TAG is used for an improved implementation,
+        #       i.e., send only a header and no body.
+        self.bcast(None, _tag=BARRIER_TAG)
+        self.gather(None, _tag=BARRIER_TAG)
+
+    def clone(self):
+        from ._init.common import find_free_port, get_authkey
+        port = find_free_port() if self.rank == 0 else None
+        authkey = get_authkey(force_random=True) if self.rank == 0 else None
+
+        # bcast and gather act as barrier
+        port, authkey = self.bcast([port, authkey])
+        self.gather(None, _tag=BARRIER_TAG)
+
+        return self.__class__(
+            rank=self.rank,
+            size=self.size,
+            port=port,
+            host=self._host,
+            authkey=authkey,
+            depth=self._depth + 1,
+            debug=self._debug,
+        )
+
+    Barrier = barrier
+    Clone = clone
+
+
+Communicator = Communicator_v3
+
+
+# class _MPI:
+#     COMM_WORLD = Communicator(rank=RANK, size=SIZE)
+#     COMM = COMM_WORLD
+#
+#     RANK = RANK
+#     SIZE = SIZE
+#
+#
+# MPI = _MPI()
+
+from ._init.get_init import get
+# _HOST, _PORT, RANK, SIZE, AUTHKEY = get()
+_kwargs = get()
+
+try:
+    COMM_WORLD = Communicator(**_kwargs)
+    COMM = COMM_WORLD
+except Exception:
+    raise RuntimeError(_kwargs)

--- a/dlp_mpi/ame/core/logger.py
+++ b/dlp_mpi/ame/core/logger.py
@@ -36,13 +36,17 @@ def info(*args, color=True, frames=1):
             outer_frame = outer_frame.f_back
         outer_frame_info = inspect.getframeinfo(outer_frame)
         try:
+            # added in py311 https://docs.python.org/3/whatsnew/changelog.html#changelog
             qualname = outer_frame.f_code.co_qualname
         except AttributeError:
-            # ToDO: Find a the reason and a proper fix for:
-            # AttributeError: 'code' object has no attribute 'co_qualname'. Did you mean: 'co_filename'?
-            qualname = '???'
-            # qualname = str(outer_frame.f_code)
-            # <code object recv at 0x..., file ".../dlp_mpi/dlp_mpi/ame/core/con_v3.py", line 207>
+            try:
+                qualname = outer_frame.f_code.co_name
+            except AttributeError:
+                # ToDO: Find a the reason and a proper fix for:
+                # AttributeError: 'code' object has no attribute 'co_qualname'. Did you mean: 'co_filename'?
+                qualname = '???'
+                # qualname = str(outer_frame.f_code)
+                # <code object recv at 0x..., file ".../dlp_mpi/dlp_mpi/ame/core/con_v3.py", line 207>
 
         file = Path(outer_frame_info.filename).name
         file_color = {

--- a/dlp_mpi/ame/core/logger.py
+++ b/dlp_mpi/ame/core/logger.py
@@ -1,0 +1,71 @@
+import inspect
+from pathlib import Path
+
+
+def info(*args, color=True, frames=1):
+    """
+    >>> foo()  # doctest: +ELLIPSIS
+    logger.py:... foo debug message
+    >>> Bar()()  # doctest: +ELLIPSIS
+    logger.py:... Bar.__call__ debug message
+    >>> Bar.static_method()  # doctest: +ELLIPSIS
+    logger.py:... Bar.static_method debug message
+    >>> Bar.class_method()  # doctest: +ELLIPSIS
+    logger.py:... Bar.class_method debug message
+    """
+    class c:
+        red = '\033[91m'
+        reset = '\033[0m'
+        magenta = '\033[95m'
+        cyan = '\033[96m'
+        yellow = '\033[93m'
+        green = '\033[92m'
+        blue = '\033[94m'
+
+    assert frames >= 1, frames
+
+    frame = inspect.currentframe()
+
+    prefix = ''
+    msg = []
+    for i in reversed(range(frames)):
+        outer_frame = frame.f_back
+        for _ in range(i):
+            outer_frame = outer_frame.f_back
+        outer_frame_info = inspect.getframeinfo(outer_frame)
+        qualname = outer_frame.f_code.co_qualname
+
+        file = Path(outer_frame_info.filename).name
+        file_color = {
+            'core.py': c.cyan,
+            'p2p.py': c.yellow,
+        }.get(file, c.red)
+        file = f'{Path(outer_frame_info.filename).name}:{outer_frame_info.lineno} {file}'
+
+        if color:
+            file = f'{file_color}{file}{c.reset}'
+            qualname = f'{c.magenta}{qualname}{c.reset}'
+
+        if i == 0:
+            msg.append(f'{prefix}{file}::{qualname} {" ".join(map(str, args))}')
+        else:
+            msg.append(f'{prefix}{file}::{qualname}')
+        prefix = f'{" "*len(prefix)} ⤷ '
+    print(*msg, sep='\n')
+
+
+def foo():
+    info('debug message', color=False)
+
+
+class Bar:
+    def __call__(self):
+        info('debug message', color=False)
+
+    @staticmethod
+    def static_method():
+        info('debug message', color=False)
+
+    @classmethod
+    def class_method(cls):
+        info('debug message', color=False)

--- a/dlp_mpi/ame/core/logger.py
+++ b/dlp_mpi/ame/core/logger.py
@@ -11,15 +11,15 @@ def info(*args, color=True, frames=1):
     ...     pytest.skip('Requires Python 3.11 or newer') 
 
     >>> foo()  # doctest: +ELLIPSIS
-    logger.py:77 foo: debug message
+    logger.py:78 foo: debug message
     >>> Bar()()  # doctest: +ELLIPSIS
-    logger.py:82 Bar.__call__: debug message
+    logger.py:83 Bar.__call__: debug message
     >>> Bar().method_exception()  # doctest: +ELLIPSIS
-    logger.py:88 Bar.method_exception: debug message
+    logger.py:89 Bar.method_exception: debug message
     >>> Bar.static_method()  # doctest: +ELLIPSIS
-    logger.py:92 Bar.static_method: debug message
+    logger.py:93 Bar.static_method: debug message
     >>> Bar.class_method()  # doctest: +ELLIPSIS
-    logger.py:96 Bar.class_method: debug message
+    logger.py:97 Bar.class_method: debug message
     """
     class c:
         red = '\033[91m'

--- a/dlp_mpi/ame/core/logger.py
+++ b/dlp_mpi/ame/core/logger.py
@@ -1,19 +1,25 @@
+import sys
 import inspect
 from pathlib import Path
 
 
 def info(*args, color=True, frames=1):
     """
+
+    >>> if sys.version_info < (3, 11):  # co_qualname was added in Python 3.11
+    ...     import pytest
+    ...     pytest.skip('Requires Python 3.11 or newer') 
+
     >>> foo()  # doctest: +ELLIPSIS
-    logger.py:68 foo: debug message
+    logger.py:77 foo: debug message
     >>> Bar()()  # doctest: +ELLIPSIS
-    logger.py:73 Bar.__call__: debug message
+    logger.py:82 Bar.__call__: debug message
     >>> Bar().method_exception()  # doctest: +ELLIPSIS
-    logger.py:79 Bar.method_exception: debug message
+    logger.py:88 Bar.method_exception: debug message
     >>> Bar.static_method()  # doctest: +ELLIPSIS
-    logger.py:83 Bar.static_method: debug message
+    logger.py:92 Bar.static_method: debug message
     >>> Bar.class_method()  # doctest: +ELLIPSIS
-    logger.py:87 Bar.class_method: debug message
+    logger.py:96 Bar.class_method: debug message
     """
     class c:
         red = '\033[91m'

--- a/dlp_mpi/ame/core/logger.py
+++ b/dlp_mpi/ame/core/logger.py
@@ -5,14 +5,15 @@ from pathlib import Path
 def info(*args, color=True, frames=1):
     """
     >>> foo()  # doctest: +ELLIPSIS
-    logger.py:58 foo: debug message
+    logger.py:68 foo: debug message
     >>> Bar()()  # doctest: +ELLIPSIS
-    logger.py:63 Bar.__call__: debug message
+    logger.py:73 Bar.__call__: debug message
     >>> Bar().method_exception()  # doctest: +ELLIPSIS
+    logger.py:79 Bar.method_exception: debug message
     >>> Bar.static_method()  # doctest: +ELLIPSIS
-    logger.py:67 Bar.static_method: debug message
+    logger.py:83 Bar.static_method: debug message
     >>> Bar.class_method()  # doctest: +ELLIPSIS
-    logger.py:71 Bar.class_method: debug message
+    logger.py:87 Bar.class_method: debug message
     """
     class c:
         red = '\033[91m'

--- a/dlp_mpi/ame/mpirun/__main__.py
+++ b/dlp_mpi/ame/mpirun/__main__.py
@@ -1,0 +1,4 @@
+from .launch_v2 import launch
+
+if __name__ == '__main__':
+    launch()

--- a/dlp_mpi/ame/mpirun/launch.py
+++ b/dlp_mpi/ame/mpirun/launch.py
@@ -1,0 +1,106 @@
+"""
+ToDO: Internode communication.
+
+"""
+
+import sys
+import subprocess
+from pathlib import Path
+import argparse
+import os
+import textwrap
+import io
+
+DEBUG = False
+
+
+def launch():
+    stdouterr = {}
+
+    workers = []
+    if Path(__file__).stem == "launch":
+
+        if DEBUG:
+            print("Launching AME Root")
+
+        parser = argparse.ArgumentParser(add_help=True)
+        parser.add_argument('-n', '-np', type=int, dest='SIZE', default=1)
+        args, workload = parser.parse_known_args()
+        size = args.SIZE
+
+        # os.execlp('python', 'python', 'my_script.py')
+
+        if not workload:
+            raise ValueError("no executable provided", sys.argv)
+
+        from ame._init.common import get_host_and_port
+        host, port = get_host_and_port()
+
+        os.environ['AME_SIZE'] = str(size)
+        os.environ['AME_PORT'] = str(port)
+        os.environ['AME_HOST'] = str(host)
+        for rank in range(1, size):
+            workers.append(subprocess.Popen(
+                ['python', '-m', 'ame.worker', *workload],
+                env=dict(os.environ, AME_RANK=str(rank)),
+                stdout=subprocess.PIPE if DEBUG else None,
+                stderr=subprocess.PIPE if DEBUG else None,
+                # start_new_session=True,
+            ))
+        os.environ['AME_RANK'] = '0'
+    elif Path(__file__).stem == "worker":
+        if DEBUG:
+            print("Launching AME Worker")
+        workload = sys.argv[1:]
+    else:
+        raise NotImplementedError("Unknown launch mode", __file__.name)
+
+    try:
+        cp = subprocess.run(
+            [*workload],
+            env=dict(os.environ),
+            stdout=subprocess.PIPE if DEBUG else None,
+            stderr=subprocess.PIPE if DEBUG else None,
+            check=False,
+        )
+    except KeyboardInterrupt:
+        class Dummy:
+            returncode = 'KeyboardInterrupt'
+        cp = Dummy()
+    if cp.returncode != 0:
+        print(f"RANK {os.environ['AME_RANK']} failed with {cp.returncode}")
+    else:
+        if DEBUG:
+            print(f"RANK {os.environ['AME_RANK']} finished.")
+
+    if DEBUG:
+        print(f"Worker {0} finished with {cp.returncode}")
+        if cp.stdout:
+            print(" stdout")
+            print(textwrap.indent(cp.stdout.decode(), " | "))
+        if cp.stderr:
+            print(" stderr")
+            print(textwrap.indent(cp.stderr.decode(), " | "))
+
+    if workers:
+        for i, worker in enumerate(workers, start=1):
+            if DEBUG:
+                stdout, stderr = worker.communicate()
+                print(f"Worker {i} finished with {worker.returncode}")
+                if stdout:
+                    print(" stdout")
+                    print(textwrap.indent(stdout.decode(), " | "))
+                if stderr:
+                    print(" stderr")
+                    print(textwrap.indent(stderr.decode(), " | "))
+            else:
+                worker.wait()
+
+        if DEBUG:
+            print("All workers finished")
+
+
+if __name__ == '__main__':
+    launch()
+
+

--- a/dlp_mpi/ame/mpirun/launch_v2.py
+++ b/dlp_mpi/ame/mpirun/launch_v2.py
@@ -1,0 +1,86 @@
+"""
+
+"""
+
+import sys
+import subprocess
+import argparse
+import os
+import textwrap
+
+DEBUG = False
+
+
+def launch():
+    workers = []
+
+    parser = argparse.ArgumentParser(add_help=True)
+    parser.add_argument('-n', '-np', type=int, dest='SIZE', default=1)
+    parser.add_argument('--pty', type=int, dest='pty', metavar='RANK', default=None,
+                        help="Connects the stdin of the process with the given "
+                             "RANK to the terminal, enabling interactive "
+                             "input (or debugging). If omitted, no process "
+                             "will have interactive input.")
+    parser.add_argument('--debug', action='store_true', dest='debug', default=DEBUG)
+    parser.add_argument('workload', nargs=argparse.REMAINDER)
+
+    # parse_known_args may consume program args
+    # args, workload = parser.parse_known_args()
+
+    args = parser.parse_args()
+    size = args.SIZE
+    debug = args.debug
+    pty = args.pty
+    workload = args.workload
+
+    # os.execlp('python', 'python', 'my_script.py')
+
+    if not workload:
+        raise ValueError("no executable provided", sys.argv)
+
+    from ..core._init.common import get_host_and_port, get_authkey, authkey_decode
+    host, port = get_host_and_port()
+
+    os.environ['AME_SIZE'] = str(size)
+    os.environ['AME_PORT'] = str(port)
+    os.environ['AME_HOST'] = str(host)
+    os.environ['AME_AUTHKEY'] = authkey_decode(get_authkey(force_random=True))
+
+    for rank in range(size):
+        workers.append(subprocess.Popen(
+            [*workload],
+            env=dict(os.environ, AME_RANK=str(rank)),
+            stdout=subprocess.PIPE if debug else None,
+            stderr=subprocess.PIPE if debug else None,
+            stdin=subprocess.DEVNULL if pty != rank else None,
+
+            # according to https://stackoverflow.com/questions/33277452/prevent-unexpected-stdin-reads-and-lock-in-subprocess
+            # helps start_new_session to disable stdin
+            # start_new_session=True if pty != rank else False,
+        ))
+
+    def wait_for_workers():
+        for i, worker in enumerate(workers):
+            if debug:
+                stdout, stderr = worker.communicate()
+                print(f"Worker {i} finished with {worker.returncode}")
+                if stdout:
+                    print(" stdout")
+                    print(textwrap.indent(stdout.decode(), " | "))
+                if stderr:
+                    print(" stderr")
+                    print(textwrap.indent(stderr.decode(), " | "))
+            else:
+                worker.wait()
+
+    try:
+        wait_for_workers()
+    except KeyboardInterrupt:
+        wait_for_workers()
+
+    if debug:
+        print("All workers finished")
+
+
+if __name__ == '__main__':
+    launch()

--- a/dlp_mpi/ame/old/debug_runtime_info.py
+++ b/dlp_mpi/ame/old/debug_runtime_info.py
@@ -3,19 +3,20 @@
 
 # print(_HOST, _PORT, SIZE, RANK)
 
-import os
+if __name__ == '__main__':
+    import os
 
-print('SLURM_SRUN', os.environ['SLURM_SRUN_COMM_HOST'], os.environ['SLURM_SRUN_COMM_PORT'], os.environ['SLURM_PROCID'], os.environ['SLURM_NTASKS'])
+    print('SLURM_SRUN', os.environ['SLURM_SRUN_COMM_HOST'], os.environ['SLURM_SRUN_COMM_PORT'], os.environ['SLURM_PROCID'], os.environ['SLURM_NTASKS'])
 
-# print('PMI', os.environ['PMI_RANK'], os.environ['PMI_SIZE'])
-# print(os.environ['OMPI_COMM_WORLD_RANK'], os.environ['OMPI_COMM_WORLD_SIZE'])
+    # print('PMI', os.environ['PMI_RANK'], os.environ['PMI_SIZE'])
+    # print(os.environ['OMPI_COMM_WORLD_RANK'], os.environ['OMPI_COMM_WORLD_SIZE'])
 
-for k, v in os.environ.items():
-    # if 'PMI' in k:
-    #     print(k, v)
-    # if 'OMPI' in k:
-    #     print(k, v)
-    if 'SLURM' in k and 'NODE' in k:
-        print(k, v[:50])
-    # if 'SRUN' in k:
-    #     print(k, v)
+    for k, v in os.environ.items():
+        # if 'PMI' in k:
+        #     print(k, v)
+        # if 'OMPI' in k:
+        #     print(k, v)
+        if 'SLURM' in k and 'NODE' in k:
+            print(k, v[:50])
+        # if 'SRUN' in k:
+        #     print(k, v)

--- a/dlp_mpi/ame/old/debug_runtime_info.py
+++ b/dlp_mpi/ame/old/debug_runtime_info.py
@@ -1,0 +1,21 @@
+# from ame.core import _HOST, _PORT, SIZE, RANK
+
+
+# print(_HOST, _PORT, SIZE, RANK)
+
+import os
+
+print('SLURM_SRUN', os.environ['SLURM_SRUN_COMM_HOST'], os.environ['SLURM_SRUN_COMM_PORT'], os.environ['SLURM_PROCID'], os.environ['SLURM_NTASKS'])
+
+# print('PMI', os.environ['PMI_RANK'], os.environ['PMI_SIZE'])
+# print(os.environ['OMPI_COMM_WORLD_RANK'], os.environ['OMPI_COMM_WORLD_SIZE'])
+
+for k, v in os.environ.items():
+    # if 'PMI' in k:
+    #     print(k, v)
+    # if 'OMPI' in k:
+    #     print(k, v)
+    if 'SLURM' in k and 'NODE' in k:
+        print(k, v[:50])
+    # if 'SRUN' in k:
+    #     print(k, v)

--- a/dlp_mpi/ame/testing.py
+++ b/dlp_mpi/ame/testing.py
@@ -11,7 +11,7 @@ def get_free_port():
         return s.getsockname()[1]
 
 
-def _in_thread(host, port, rank, size, callback, out: dict):
+def _in_thread(*, host, port, rank, size, authkey, callback, out: dict):
     """
     >>> _in_thread('localhost', 12345, 0, 2, lambda rank, size: print(f'Hello from {rank}/{size}'), {})
     Hello from 0/2
@@ -20,7 +20,7 @@ def _in_thread(host, port, rank, size, callback, out: dict):
     import inspect
     kwargs = {
         k: v
-        for k, v in dict(host=host, port=port, rank=rank, size=size).items()
+        for k, v in dict(host=host, port=port, rank=rank, size=size, authkey=authkey).items()
         if k in inspect.signature(callback).parameters
     }
 
@@ -37,12 +37,13 @@ def thread_based_test(callback, size, in_main=0):
     port = get_free_port()
     # host = 'localhost'
     host = socket.gethostname()
+    authkey = b'abc'
     assert size > 0, size
 
     threads = {}
     out = {}
     for rank in sorted(range(size), key=lambda x: size if x == in_main else x):
-        kwargs = dict(host=host, port=port, rank=rank, size=size, callback=callback, out=out)
+        kwargs = dict(host=host, port=port, rank=rank, size=size, callback=callback, authkey=authkey, out=out)
         if rank == 0:
             _in_thread(**kwargs)
         else:

--- a/dlp_mpi/ame/testing.py
+++ b/dlp_mpi/ame/testing.py
@@ -11,7 +11,7 @@ def get_free_port():
         return s.getsockname()[1]
 
 
-def _in_thread(*, host, port, rank, size, authkey, callback, out: dict):
+def _in_thread(*, host, port, port2, rank, size, authkey, callback, out: dict):
     """
     >>> _in_thread('localhost', 12345, 0, 2, lambda rank, size: print(f'Hello from {rank}/{size}'), {})
     Hello from 0/2
@@ -20,7 +20,7 @@ def _in_thread(*, host, port, rank, size, authkey, callback, out: dict):
     import inspect
     kwargs = {
         k: v
-        for k, v in dict(host=host, port=port, rank=rank, size=size, authkey=authkey).items()
+        for k, v in dict(host=host, port=port, port2=port2, rank=rank, size=size, authkey=authkey).items()
         if k in inspect.signature(callback).parameters
     }
 
@@ -35,6 +35,7 @@ def _in_thread(*, host, port, rank, size, authkey, callback, out: dict):
 
 def thread_based_test(callback, size, in_main=0):
     port = get_free_port()
+    port2 = get_free_port()
     # host = 'localhost'
     host = socket.gethostname()
     authkey = b'abc'
@@ -43,7 +44,7 @@ def thread_based_test(callback, size, in_main=0):
     threads = {}
     out = {}
     for rank in sorted(range(size), key=lambda x: size if x == in_main else x):
-        kwargs = dict(host=host, port=port, rank=rank, size=size, callback=callback, authkey=authkey, out=out)
+        kwargs = dict(host=host, port=port, port2=port2, rank=rank, size=size, callback=callback, authkey=authkey, out=out)
         if rank == 0:
             _in_thread(**kwargs)
         else:

--- a/dlp_mpi/ame/testing.py
+++ b/dlp_mpi/ame/testing.py
@@ -13,7 +13,7 @@ def get_free_port():
 
 def _in_thread(*, host, port, port2, rank, size, authkey, callback, out: dict):
     """
-    >>> _in_thread('localhost', 12345, 0, 2, lambda rank, size: print(f'Hello from {rank}/{size}'), {})
+    >>> _in_thread(host='localhost', port=12345, port2=12346, rank=0, size=2, authkey=b'abc', callback=lambda rank, size: print(f'Hello from {rank}/{size}'), out={})
     Hello from 0/2
     """
 

--- a/dlp_mpi/ame/testing.py
+++ b/dlp_mpi/ame/testing.py
@@ -1,0 +1,59 @@
+import threading
+import socket
+import contextlib
+import io
+import sys
+
+
+def get_free_port():
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("",0))
+        return s.getsockname()[1]
+
+
+def _in_thread(host, port, rank, size, callback, out: dict):
+    """
+    >>> _in_thread('localhost', 12345, 0, 2, lambda rank, size: print(f'Hello from {rank}/{size}'), {})
+    Hello from 0/2
+    """
+
+    import inspect
+    kwargs = {
+        k: v
+        for k, v in dict(host=host, port=port, rank=rank, size=size).items()
+        if k in inspect.signature(callback).parameters
+    }
+
+    try:
+        out[rank] = callback(**kwargs)
+    except BaseException as e:
+        import traceback
+        print(f'Rank {rank} of {size}: {e}')
+        traceback.print_exc()
+        raise
+
+
+def thread_based_test(callback, size, in_main=0):
+    port = get_free_port()
+    # host = 'localhost'
+    host = socket.gethostname()
+    assert size > 0, size
+
+    threads = {}
+    out = {}
+    for rank in sorted(range(size), key=lambda x: size if x == in_main else x):
+        kwargs = dict(host=host, port=port, rank=rank, size=size, callback=callback, out=out)
+        if rank == 0:
+            _in_thread(**kwargs)
+        else:
+            t = threading.Thread(target=_in_thread, kwargs=kwargs)
+            t.daemon = True
+            t.start()
+            threads[rank] = t
+
+    for i, t in threads.items():
+        print(f'Wait for thread {i}')
+        t.join()
+        print(f'Thread {i} finished')
+
+    return out

--- a/dlp_mpi/mpi.py
+++ b/dlp_mpi/mpi.py
@@ -97,6 +97,11 @@ except ImportError:
     if int(os.environ.get('SLURM_STEP_NUM_TASKS', '1')) != 1:
         raise
 
+    _backend == 'none'
+
+
+print(f'Using {_backend!r} as backend (DLP_MPI_BACKEND={os.environ.get("DLP_MPI_BACKEND", "")})')
+
 
 if not _mpi_available:
     # Fallback to a dummy mpi implementation to run on platforms that do not

--- a/dlp_mpi/mpi.py
+++ b/dlp_mpi/mpi.py
@@ -39,11 +39,21 @@ try:
         # it is not used.
         # Bug: The second MPI Job in a job step fails.
         raise ImportError()
+    
+    _backend = os.environ.get('DLP_MPI_BACKEND', '').lower()
 
-    if 'AME_RANK' in os.environ or os.environ.get('DLP_MPI_BACKEND', 'mpi4py').lower() == 'ame':
+    if _backend == 'ame':
         from dlp_mpi.ame import MPI
-    else:
+    elif _backend in ['mpi4py', '']:
         from mpi4py import MPI
+    elif _backend == '' and 'AME_RANK' in os.environ:
+        from dlp_mpi.ame import MPI
+    elif _backend == 'none':
+        raise ImportError("No backend selected. If you see this, you started a job with MPI, while DLP_MPI_BACKEND=none.")
+    else:
+        raise RuntimeError(f'Unknown DLP_MPI_BACKEND: {_backend}.\n'
+                           'Please set it to "ame" or "mpi4py".\n'
+                           'If you unset it, it will default to "mpi4py".')
 
     if MPI.COMM_WORLD.size > 1:
         if False:

--- a/dlp_mpi/mpi.py
+++ b/dlp_mpi/mpi.py
@@ -97,7 +97,7 @@ except ImportError:
     if int(os.environ.get('SLURM_STEP_NUM_TASKS', '1')) != 1:
         raise
 
-    _backend == 'none'
+    _backend = 'none'
 
 
 # print(f'Using {_backend!r} as backend (DLP_MPI_BACKEND={os.environ.get("DLP_MPI_BACKEND", "")})')

--- a/dlp_mpi/mpi.py
+++ b/dlp_mpi/mpi.py
@@ -100,7 +100,7 @@ except ImportError:
     _backend == 'none'
 
 
-print(f'Using {_backend!r} as backend (DLP_MPI_BACKEND={os.environ.get("DLP_MPI_BACKEND", "")})')
+# print(f'Using {_backend!r} as backend (DLP_MPI_BACKEND={os.environ.get("DLP_MPI_BACKEND", "")})')
 
 
 if not _mpi_available:

--- a/dlp_mpi/mpi.py
+++ b/dlp_mpi/mpi.py
@@ -84,7 +84,7 @@ except ImportError:
         )
         raise
 
-    if int(os.environ.get('SLURM_STEP_NUM_TASKS', 'unknown')) != 1:
+    if int(os.environ.get('SLURM_STEP_NUM_TASKS', '1')) != 1:
         raise
 
 

--- a/dlp_mpi/mpi.py
+++ b/dlp_mpi/mpi.py
@@ -41,7 +41,7 @@ try:
         raise ImportError()
 
     if 'AME_RANK' in os.environ or os.environ.get('DLP_MPI_BACKEND', 'mpi4py').lower() == 'ame':
-        from ame import MPI
+        from dlp_mpi.ame import MPI
     else:
         from mpi4py import MPI
 

--- a/dlp_mpi/mpi.py
+++ b/dlp_mpi/mpi.py
@@ -44,10 +44,10 @@ try:
 
     if _backend == 'ame':
         from dlp_mpi.ame import MPI
-    elif _backend in ['mpi4py', '']:
-        from mpi4py import MPI
     elif _backend == '' and 'AME_RANK' in os.environ:
         from dlp_mpi.ame import MPI
+    elif _backend in ['mpi4py', '']:
+        from mpi4py import MPI
     elif _backend == 'none':
         raise ImportError("No backend selected. If you see this, you started a job with MPI, while DLP_MPI_BACKEND=none.")
     else:

--- a/dlp_mpi/mpi.py
+++ b/dlp_mpi/mpi.py
@@ -40,7 +40,11 @@ try:
         # Bug: The second MPI Job in a job step fails.
         raise ImportError()
 
-    from mpi4py import MPI
+    if 'AME_RANK' in os.environ or os.environ.get('DLP_MPI_BACKEND', 'mpi4py').lower() == 'ame':
+        from ame import MPI
+    else:
+        from mpi4py import MPI
+
     if MPI.COMM_WORLD.size > 1:
         if False:
             # Usually data-level parallelism is better than low-level

--- a/examples/mpi_5_map_unordered.py
+++ b/examples/mpi_5_map_unordered.py
@@ -12,7 +12,7 @@ import numpy as np
 
 
 def fn(example_id):
-    time.sleep(np.random.uniform(0, 1))
+    time.sleep(np.random.uniform(0, 0.2))
     example = 'hello'
     print(RANK, example_id, example[example_id])
     return example[example_id]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,7 @@
+[pytest]
+addopts =
+    --doctest-modules
+    --doctest-continue-on-failure
+    --cov=dlp_mpi
+    --cov-report=xml
+    --cov-report=html

--- a/setup.py
+++ b/setup.py
@@ -126,6 +126,7 @@ setup(
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.13',
     ],
 
     # This field adds keywords for your project which will appear on the

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,9 @@ extras_require['pmix'] = ['cffi']
 extras_require['test'] = [
     *extras_require['optional'], *extras_require['mpi4py'], *extras_require['pmix'], 
     'pytest',
+    'pytest-cov',
     'numpy',
+    'flake8'
 ]
 extras_require['all'] = list(dict.fromkeys([
     e for k, v in extras_require.items() if k != 'all' for e in v

--- a/setup.py
+++ b/setup.py
@@ -155,6 +155,8 @@ setup(
     # Similar to `install_requires` above, these must be valid existing
     # projects.
     extras_require={  # Optional
+        'mpi4py': ['mpi4py'],
+        'all': ['mpi4py'],
         # 'dev': ['check-manifest'],
         # 'test': ['coverage'],
     },

--- a/setup.py
+++ b/setup.py
@@ -19,13 +19,16 @@ with open(path.join(here, 'README.md'), encoding='utf-8') as f:
 # Fields marked as "Optional" may be commented out.
 
 extras_require = {}
+extras_require['optional'] = [
+    'tqdm',  # when a progress bar is enabled/used
+    'paderbox',  # dlp_mpi.collection.NestedDict
+]
 extras_require['mpi4py'] = ['mpi4py']
 extras_require['pmix'] = ['cffi']
 extras_require['test'] = [
-    *extras_require['mpi4py'], *extras_require['pmix'], 
+    *extras_require['optional'], *extras_require['mpi4py'], *extras_require['pmix'], 
     'pytest',
     'numpy',
-    'paderbox',  # dlp_mpi.collection.NestedDict
 ]
 extras_require['all'] = list(dict.fromkeys([
     e for k, v in extras_require.items() if k != 'all' for e in v

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,15 @@ with open(path.join(here, 'README.md'), encoding='utf-8') as f:
 # Arguments marked as "Required" below must be included for upload to PyPI.
 # Fields marked as "Optional" may be commented out.
 
+extras_require = {}
+extras_require['mpi4py'] = ['mpi4py']
+extras_require['pmix'] = ['cffi']
+extras_require['test'] = [*extras_require['mpi4py'], *extras_require['pmix'], 'pytest', 'numpy']
+extras_require['all'] = list(dict.fromkeys([
+    e for k, v in extras_require.items() if k != 'all' for e in v
+]).keys())
+
+
 setup(
     # This is the name of your project. The first time you publish this
     # package, this name will be registered for you. It will determine how
@@ -154,12 +163,7 @@ setup(
     #
     # Similar to `install_requires` above, these must be valid existing
     # projects.
-    extras_require={  # Optional
-        'mpi4py': ['mpi4py'],
-        'all': ['mpi4py'],
-        # 'dev': ['check-manifest'],
-        # 'test': ['coverage'],
-    },
+    extras_require=extras_require,
 
     # If there are data files included in your packages that need to be
     # installed, specify them here.

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,12 @@ with open(path.join(here, 'README.md'), encoding='utf-8') as f:
 extras_require = {}
 extras_require['mpi4py'] = ['mpi4py']
 extras_require['pmix'] = ['cffi']
-extras_require['test'] = [*extras_require['mpi4py'], *extras_require['pmix'], 'pytest', 'numpy']
+extras_require['test'] = [
+    *extras_require['mpi4py'], *extras_require['pmix'], 
+    'pytest',
+    'numpy',
+    'paderbox',  # dlp_mpi.collection.NestedDict
+]
 extras_require['all'] = list(dict.fromkeys([
     e for k, v in extras_require.items() if k != 'all' for e in v
 ]).keys())

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
     # This is a one-line description or tagline of what your project does. This
     # corresponds to the "Summary" metadata field:
     # https://packaging.python.org/specifications/core-metadata/#summary
-    description='Data-level parallelism with mpi in python',  # Optional
+    description='Data-level parallelism with MPI in python',  # Optional
 
     # This is an optional longer description of your project that represents
     # the body of text which users will see when they visit PyPI.
@@ -142,7 +142,7 @@ setup(
     # For an analysis of "install_requires" vs pip's requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
     install_requires=[
-        'mpi4py'
+        # 'mpi4py'
         # 'peppercorn'
     ],  # Optional
 
@@ -185,9 +185,10 @@ setup(
     # For example, the following would provide a command called `sample` which
     # executes the function `main` from this package when invoked:
     entry_points={  # Optional
-        # 'console_scripts': [
-        #     'sample=sample:main',
-        # ],
+        'console_scripts': [
+            'amerun=dlp_mpi.ame.mpirun.__main__:launch',
+            'ameexec=dlp_mpi.ame.mpirun.__main__:launch',
+        ],
     },
 
     # List additional URLs that are relevant to your project as a dict.

--- a/setup.py
+++ b/setup.py
@@ -8,11 +8,6 @@ https://github.com/pypa/sampleproject
 # Always prefer setuptools over distutils
 from setuptools import setup, find_packages
 from os import path
-# io.open is needed for projects that support Python 2.7
-# It ensures open() defaults to text mode with universal newlines,
-# and accepts an argument to specify the text encoding
-# Python 3 only projects can skip this import
-from io import open
 
 here = path.abspath(path.dirname(__file__))
 
@@ -108,7 +103,7 @@ setup(
         #   3 - Alpha
         #   4 - Beta
         #   5 - Production/Stable
-        'Development Status :: 3 - Alpha',
+        'Development Status :: 4 - Beta',
 
         # Indicate who your project is intended for
         'Intended Audience :: Developers',
@@ -121,8 +116,11 @@ setup(
         # that you indicate whether you support Python 2, Python 3 or both.
         # These classifiers are *not* checked by 'pip install'. See instead
         # 'python_requires' below.
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
 
     # This field adds keywords for your project which will appear on the
@@ -147,7 +145,7 @@ setup(
     # and refuse to install the project if the version does not match. If you
     # do not support Python 2, you can simplify this to '>=3.5' or similar, see
     # https://packaging.python.org/guides/distributing-packages-using-setuptools/#python-requires
-    python_requires='>=3.6, <4',
+    python_requires='>=3.8, <4',
 
     # This field lists other packages that your project depends on to run.
     # Any package you put here will be installed by pip when your project is

--- a/tests/burn_tests.py
+++ b/tests/burn_tests.py
@@ -56,14 +56,14 @@ def exec_code(code, size=2, backend='ame'):
         return out
 
 
-def test_1(backend, size=2):
+def mpi_1(backend, size=2):
     """
-    >>> test_1('mpi4py')
+    >>> mpi_1('mpi4py')
     rank=0, size=2
     <BLANKLINE>
     rank=1, size=2
     <BLANKLINE>
-    >>> test_1('ame')
+    >>> mpi_1('ame')
     rank=0, size=2
     <BLANKLINE>
     rank=1, size=2
@@ -73,27 +73,27 @@ def test_1(backend, size=2):
         print(output)
 
 
-def test_2(backend, size=2):
+def mpi_2(backend, size=2):
     """
-    >>> test_2('mpi4py')
+    >>> mpi_2('mpi4py')
     rank=0, size=2, data={'key1': [7, 2.72, (2+3j)], 'key2': ('abc', 'xyz')}
     <BLANKLINE>
     rank=1, size=2, data={'key1': [7, 2.72, (2+3j)], 'key2': ('abc', 'xyz')}
     <BLANKLINE>
-    >>> test_2('ame')
+    >>> mpi_2('ame')
     """
     for output in exec_code((examples_folder / 'mpi_2_broadcast_data.py').read_text(), size=size, backend=backend):
         print(output)
 
 
-def test_3(backend, size=2):
+def mpi_3(backend, size=2):
     """
-    >>> test_3('mpi4py')
+    >>> mpi_3('mpi4py')
     rank=0, size=2, data=['hello', 'world']
     <BLANKLINE>
     rank=1, size=2, data=None
     <BLANKLINE>
-    >>> test_3('ame')
+    >>> mpi_3('ame')
     rank=0, size=2, data=['hello', 'world']
     <BLANKLINE>
     rank=1, size=2, data=None
@@ -103,9 +103,9 @@ def test_3(backend, size=2):
         print(output)
 
 
-def test_4(backend, size=2):
+def mpi_4(backend, size=2):
     """
-    >>> test_4('mpi4py')
+    >>> mpi_4('mpi4py')
     rank=0, size=2, data=10
     rank=0, size=2, data=12
     job splits: [[20, 24], [22, 26]]
@@ -114,7 +114,7 @@ def test_4(backend, size=2):
     rank=1, size=2, data=11
     rank=1, size=2, data=13
     <BLANKLINE>
-    >>> test_4('ame')
+    >>> mpi_4('ame')
     rank=0, size=2, data=10
     rank=0, size=2, data=12
     job splits: [[20, 24], [22, 26]]
@@ -128,10 +128,10 @@ def test_4(backend, size=2):
         print(output)
 
 
-def test_5(backend, size=2):
+def mpi_5(backend, size=2):
     """
 
-    >>> test_5('mpi4py')
+    >>> mpi_5('mpi4py')
     ### Unordered map scattered around processes:
     ['h', 'e', 'l', 'l', 'o']
     ### Map function run only on master:
@@ -148,7 +148,7 @@ def test_5(backend, size=2):
     1 3 l
     1 4 o
     <BLANKLINE>
-    >>> test_5('ame')
+    >>> mpi_5('ame')
     ### Unordered map scattered around processes:
     ['h', 'e', 'l', 'l', 'o']
     ### Map function run only on master:
@@ -170,9 +170,10 @@ def test_5(backend, size=2):
         print(output)
 
 
-def test_5_3(backend, size=3):
+def mpi_5_3(backend, size=3):
     """
-    >>> test_5_3()
+    >>> mpi_5_3('mpi4py')
+    >>> mpi_5_3('ame')
     """
     outputs = exec_code((examples_folder / 'mpi_5_map_unordered.py').read_text(), size=size, backend=backend)
 

--- a/tests/burn_tests.py
+++ b/tests/burn_tests.py
@@ -16,7 +16,7 @@ def run(cmd, cwd=None, check=True):
 
 
 def test():
-    result = run("mpiexec -np 2 python -c 'import dlp_mpi; print(dlp_mpi.RANK)'")
+    result = run("mpiexec --oversubscribe -np 2 python -c 'import dlp_mpi; print(dlp_mpi.RANK)'")
     assert result.stdout in ['0\n1\n', '1\n0\n'], f"Unexpected output: {result.stdout}"
 
 
@@ -31,7 +31,9 @@ def exec_code(code, size=2):
         tmpdir = Path(tmpdir)
         (tmpdir / 'code.py').write_text(code)
         try:
-            run(["mpiexec", "-np", f"{size}", "bash", "-c", f"python {tmpdir / 'code.py'} > {tmpdir / '$OMPI_COMM_WORLD_RANK.txt'}"], cwd=tmpdir)
+            # --oversubscribe: mpiexec fails, if the number of physical cores is less than SIZE.
+            #                  With this option it will run anyway.
+            run(["mpiexec", "--oversubscribe", "-np", f"{size}", "bash", "-c", f"python {tmpdir / 'code.py'} > {tmpdir / '$OMPI_COMM_WORLD_RANK.txt'}"], cwd=tmpdir)
         except subprocess.CalledProcessError as e:
             for rank in range(size):
                 try:

--- a/tests/burn_tests.py
+++ b/tests/burn_tests.py
@@ -81,6 +81,10 @@ def mpi_2(backend, size=2):
     rank=1, size=2, data={'key1': [7, 2.72, (2+3j)], 'key2': ('abc', 'xyz')}
     <BLANKLINE>
     >>> mpi_2('ame')
+    rank=0, size=2, data={'key1': [7, 2.72, (2+3j)], 'key2': ('abc', 'xyz')}
+    <BLANKLINE>
+    rank=1, size=2, data={'key1': [7, 2.72, (2+3j)], 'key2': ('abc', 'xyz')}
+    <BLANKLINE>
     """
     for output in exec_code((examples_folder / 'mpi_2_broadcast_data.py').read_text(), size=size, backend=backend):
         print(output)

--- a/tests/burn_tests.py
+++ b/tests/burn_tests.py
@@ -1,0 +1,151 @@
+import subprocess
+from pathlib import Path
+import tempfile
+import shlex
+
+examples_folder = Path(__file__).parent.parent / 'examples'
+
+
+def run(cmd, cwd=None, check=True):
+    """Run a command in a subprocess."""
+    try:
+        return subprocess.run(cmd, shell=isinstance(cmd, str), check=check, capture_output=True, text=True, cwd=cwd, universal_newlines=True)
+    except subprocess.CalledProcessError as e:
+        e.add_note(f'\n\nstdout: {e.stdout}\nstderr: {e.stderr}')
+        raise
+
+
+def test():
+    result = run("mpiexec -np 2 python -c 'import dlp_mpi; print(dlp_mpi.RANK)'")
+    assert result.stdout in ['0\n1\n', '1\n0\n'], f"Unexpected output: {result.stdout}"
+
+
+def exec_code(code, size=2):
+    """
+    Execute code with mpiexec -np <size> ....
+
+    Catch the stdout of each rank and return it, ordered by RANK.
+
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmpdir = Path(tmpdir)
+        (tmpdir / 'code.py').write_text(code)
+        run(["mpiexec", "-np", f"{size}", "bash", "-c", f"python {tmpdir / 'code.py'} > {tmpdir / '$OMPI_COMM_WORLD_RANK.txt'}"], cwd=tmpdir)
+        assert set(tmpdir.glob("*.txt")) == {tmpdir / f"{rank}.txt" for rank in range(size)}, f"Expected {size} output files, found: {list(tmpdir.glob('*.txt'))}"
+        out = []
+        for rank in range(size):
+            out.append((tmpdir / f"{rank}.txt").read_text())
+        return out
+
+
+def test_1(size=2):
+    """
+    >>> test_1()
+    rank=0, size=2
+    <BLANKLINE>
+    rank=1, size=2
+    <BLANKLINE>
+    """
+    for output in exec_code((examples_folder / 'mpi_1_rank_and_size.py').read_text(), size=size):
+        print(output)
+
+
+def test_2(size=2):
+    """
+    >>> test_2()
+    rank=0, size=2, data={'key1': [7, 2.72, (2+3j)], 'key2': ('abc', 'xyz')}
+    <BLANKLINE>
+    rank=1, size=2, data={'key1': [7, 2.72, (2+3j)], 'key2': ('abc', 'xyz')}
+    <BLANKLINE>
+    """
+    for output in exec_code((examples_folder / 'mpi_2_broadcast_data.py').read_text(), size=size):
+        print(output)
+
+
+def test_3(size=2):
+    """
+    >>> test_3()
+    rank=0, size=2, data=['hello', 'world']
+    <BLANKLINE>
+    rank=1, size=2, data=None
+    <BLANKLINE>
+    """
+    for output in exec_code((examples_folder / 'mpi_3_gather_data.py').read_text(), size=size):
+        print(output)
+
+
+def test_4(size=2):
+    """
+    >>> test_4()
+    rank=0, size=2, data=10
+    rank=0, size=2, data=12
+    job splits: [[20, 24], [22, 26]]
+    flat result:  [20, 24, 22, 26]
+    <BLANKLINE>
+    rank=1, size=2, data=11
+    rank=1, size=2, data=13
+    <BLANKLINE>
+    """
+    for output in exec_code((examples_folder / 'mpi_4_scatter_gather.py').read_text(), size=size):
+        print(output)
+
+
+def test_5(size=2):
+    """
+
+    >>> test_5()
+    ### Unordered map scattered around processes:
+    ['h', 'e', 'l', 'l', 'o']
+    ### Map function run only on master:
+    0 0 h
+    0 1 e
+    0 2 l
+    0 3 l
+    0 4 o
+    ['h', 'e', 'l', 'l', 'o']
+    <BLANKLINE>
+    1 0 h
+    1 1 e
+    1 2 l
+    1 3 l
+    1 4 o
+    <BLANKLINE>
+    """
+    for output in exec_code((examples_folder / 'mpi_5_map_unordered.py').read_text(), size=size):
+        print(output)
+
+
+def test_5_3(size=3):
+    """
+    >>> test_5_3()
+    """
+    outputs = exec_code((examples_folder / 'mpi_5_map_unordered.py').read_text(), size=size)
+
+    for expected in [
+            ' 0 h\n',
+            ' 1 e\n',
+            ' 2 l\n',
+            ' 3 l\n',
+            ' 4 o\n',
+    ]:
+        assert any(
+            expected in output
+            for output in outputs[1:]
+        ), f"Expected {expected!r} in outputs[1:], but got: {outputs[1:]}"
+
+    assert any([
+        "['h', 'e', 'l', 'l', 'o']\n###" in outputs[0],
+        "['h', 'e', 'l', 'o', 'l']\n###" in outputs[0],
+        "['h', 'e', 'o', 'l', 'l']\n###" in outputs[0],
+        "['e', 'h', 'l', 'l', 'o']\n###" in outputs[0],
+        "['e', 'h', 'l', 'o', 'l']\n###" in outputs[0],
+        "['e', 'h', 'o', 'l', 'l']\n###" in outputs[0],
+        "['e', 'l', 'h', 'o', 'l']\n###" in outputs[0],
+        "['e', 'l', 'h', 'l', 'o']\n###" in outputs[0],
+        "['e', 'l', 'l', 'h', 'o']\n###" in outputs[0],
+        "['e', 'l', 'l', 'o', 'h']\n###" in outputs[0],
+        "['h', 'l', 'e', 'o', 'l']\n###" in outputs[0],
+        "['h', 'l', 'e', 'l', 'o']\n###" in outputs[0],
+        "['h', 'l', 'l', 'e', 'o']\n###" in outputs[0],
+        "['h', 'l', 'l', 'o', 'e']\n###" in outputs[0],
+    ]), outputs[0]


### PR DESCRIPTION
Ame (French for "soul") implements a subset of the features of mpi4py, selected to meet the common requirements of dlp_mpi.

The motivation behind this is to address the challenges with reliable installation of mpi4py across various environments such as local machines, servers, and HPC clusters using Anaconda. By not relying on binaries, ame avoids issues related to binary compatibility.

By default, dlp_mpi uses mpi4py. You can switch to the alternative backend by setting the `DLP_MPI_BACKEND=ame` environment variable.